### PR TITLE
Flatpak related optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cmake-build-debug/
 build/
 tests/
 .flatpak-builder/
+flatpak/repo/
 
 # Object files
 *.o

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ To install Flatpak, follow the [official guide](https://flatpak.org/getting.html
 flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak install flathub com.github.paolostivanin.OTPClient
 ```
-Please note that with the flatpak version you won't be asked where to store the database. Instead, the software will use the app's data directory (`/home/USER/.var/app/com.github.paolostivanin.OTPClient/data`)
-This change was necessary in order to restrict the app's permissions to the filesystem (from the initial `filesystem=home` to nothing).
+
+:warning: Please note that with the flatpak version you **won't** be asked where to store the database. Instead, the software will use the app's data directory (`/home/USER/.var/app/com.github.paolostivanin.OTPClient/data`)
+This change was necessary in order to restrict the app's permissions to **NOT HAVE** full access to the host's filesystem.
+Because of that, if you want to import a file you have to place it under the aforementioned folder (`/home/USER/.var/app/com.github.paolostivanin.OTPClient/data`).
 
 ## License
 This software is released under the GPLv3 license. Please have a look at the [LICENSE](LICENSE) file for more details.

--- a/src/app.c
+++ b/src/app.c
@@ -128,7 +128,8 @@ activate (GtkApplication    *app,
 
 
 static void
-get_saved_window_size (gint *width, gint *height)
+get_saved_window_size (gint *width,
+                       gint *height)
 {
     GError *err = NULL;
     GKeyFile *kf = g_key_file_new ();

--- a/src/imports.c
+++ b/src/imports.c
@@ -35,6 +35,10 @@ select_file_cb (GSimpleAction *simple,
                                                      "Open", GTK_RESPONSE_ACCEPT,
                                                      NULL);
 
+#ifdef USE_FLATPAK_APP_FOLDER
+    gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), g_get_user_data_dir ());
+#endif
+
     gint res = gtk_dialog_run (GTK_DIALOG (dialog));
     if (res == GTK_RESPONSE_ACCEPT) {
         GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);


### PR DESCRIPTION
When importing a file, an empty window is shown because the app does not have full access to the host's file system. With this change, the app's data folder is shown instead.