### PR TITLE
Release 1.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(USE_FLATPAK_APP_FOLDER "Use flatpak app's config folder to store the database" OFF)
 
 set(OTPCLIENT_VERSION_MAJOR "1")
-set(OTPCLIENT_VERSION_MINOR "3")
-set(OTPCLIENT_VERSION_PATCH "1")
+set(OTPCLIENT_VERSION_MINOR "4")
+set(OTPCLIENT_VERSION_PATCH "0")
 set(OTPCLIENT_VERSION "${OTPCLIENT_VERSION_MAJOR}.${OTPCLIENT_VERSION_MINOR}.${OTPCLIENT_VERSION_PATCH}")
 
 set(CMAKE_C_STANDARD 11)
@@ -83,7 +83,8 @@ set(HEADER_FILES
         src/parse-uri.h
         src/password-cb.h
         src/qrcode-parser.h
-        src/treeview.h)
+        src/treeview.h
+        src/exports.h)
 
 set(SOURCE_FILES
         src/add-common.c
@@ -110,7 +111,8 @@ set(SOURCE_FILES
         src/settings.c
         src/shortcuts.c
         src/treeview.c
-        src/webcam-add-cb.c)
+        src/webcam-add-cb.c
+        src/exports.c)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
 target_link_libraries(${PROJECT_NAME}

--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     OTPClient - Simple GTK+ software to generate OTPs
-    Copyright (C) 2017 Paolo Stivanin
+    Copyright (C) 2019 Paolo Stivanin
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Highly secure and easy to use GTK+ software for two-factor authentication that s
 - support SHA1, SHA256 and SHA512 algorithms
 - support for Steam codes (please read [THIS PAGE](https://github.com/paolostivanin/OTPClient/wiki/Steam-Support))
 - import encrypted [Authenticator Plus](https://www.authenticatorplus.com/) backup
-- import encrypted [andOTP](https://github.com/flocke/andOTP) backup
+- import and export encrypted [andOTP](https://github.com/flocke/andOTP) backup
 - local database is encrypted using AES256-GCM
   - key is derived using PBKDF2 with SHA512 and 100k iterations
   - decrypted file is never saved (and hopefully never swapped) to disk. While the app is running, the decrypted content resides in a "secure memory" buffer allocated by Gcrypt

--- a/data/com.github.paolostivanin.OTPClient.appdata.xml
+++ b/data/com.github.paolostivanin.OTPClient.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018 Paolo Stivanin <info@paolostivanin.com> -->
+<!-- Copyright 2019 Paolo Stivanin <info@paolostivanin.com> -->
 <component type="desktop-application">
   <id type="desktop">com.github.paolostivanin.OTPClient.desktop</id>
   <metadata_license>CC-BY-4.0</metadata_license>
@@ -83,6 +83,15 @@ It's also possible to import encrypted backups from andOTP and Authenticator+.
   </content_rating>
 
   <releases>
+    <release version="1.4.0" date="2019-02-23">
+      <description>
+        <p>OTPClient 1.4.0 brings full support to andOTP.</p>
+        <ul>
+          <li>it's now possible to export encrypted andOTP backups</li>
+          <li>use monospace to show the database path on startup</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.3.1" date="2018-10-31">
       <description>
         <p>OTPClient 1.3.1 brings some fixes to bugs that were introduced with the previous version.</p>

--- a/flatpak/com.github.paolostivanin.OTPClient.yaml
+++ b/flatpak/com.github.paolostivanin.OTPClient.yaml
@@ -38,8 +38,8 @@ modules:
   - "/lib/*.la"
   sources:
   - type: archive
-    url: http://www.digip.org/jansson/releases/jansson-2.11.tar.gz
-    sha256: 6e85f42dabe49a7831dbdd6d30dca8a966956b51a9a50ed534b82afc3fa5b2f4
+    url: http://www.digip.org/jansson/releases/jansson-2.12.tar.gz
+    sha256: 5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9
 - name: zbar
   config-opts:
   - "--without-qt"
@@ -81,8 +81,8 @@ modules:
   - "/include"
   sources:
   - type: archive
-    url: https://github.com/paolostivanin/libcotp/archive/v1.2.1.tar.gz
-    sha256: 52ea9d876d8465aad666bdb38a59d85f183a0e8d2aa14b14d07e4e6bc471648e
+    url: https://github.com/paolostivanin/libcotp/archive/v1.2.2.tar.gz
+    sha256: 25b45ffa4aece5cc689503ebea7356a2f760c194f0c41805934495d2fe7165b1
 - name: OTPClient
   buildsystem: cmake-ninja
   config-opts:

--- a/src/andotp.c
+++ b/src/andotp.c
@@ -240,6 +240,11 @@ parse_json_data (const gchar *data,
         } else if (g_ascii_strcasecmp (type, "HOTP") == 0) {
             otp->type = g_strdup (type);
             otp->counter = json_integer_value (json_object_get (obj, "counter"));
+        } else if (g_ascii_strcasecmp (type, "Steam") == 0) {
+            otp->type = g_strdup ("TOTP");
+            otp->period = (guint32)json_integer_value (json_object_get (obj, "period"));
+            g_free (otp->issuer);
+            otp->issuer = g_strdup ("Steam");
         } else {
             g_set_error (err, generic_error_gquark (), GENERIC_ERRCODE, "otp type is neither TOTP nor HOTP");
             gcry_free (otp->secret);

--- a/src/app.c
+++ b/src/app.c
@@ -5,6 +5,7 @@
 #include "common.h"
 #include "gquarks.h"
 #include "imports.h"
+#include "exports.h"
 #include "message-dialogs.h"
 #include "password-cb.h"
 #include "get-builder.h"
@@ -119,7 +120,7 @@ activate (GtkApplication    *app,
     app_data->db_data->last_hotp_update = g_date_time_add_seconds (g_date_time_new_now_local (), -(G_TIME_SPAN_SECOND * HOTP_RATE_LIMIT_IN_SEC));
 
     retry:
-    app_data->db_data->key = prompt_for_password (app_data, NULL, NULL);
+    app_data->db_data->key = prompt_for_password (app_data, NULL, NULL, FALSE);
     if (app_data->db_data->key == NULL) {
         g_free (app_data->db_data);
         g_application_quit (G_APPLICATION(app));
@@ -222,7 +223,7 @@ set_action_group (GtkBuilder *builder,
     static GActionEntry settings_menu_entries[] = {
             { .name = ANDOTP_IMPORT_ACTION_NAME, .activate = select_file_cb },
             { .name = AUTHPLUS_IMPORT_ACTION_NAME, .activate = select_file_cb },
-            { .name = "export", .activate = NULL },
+            { .name = ANDOTP_EXPORT_ACTION_NAME, .activate = export_data_cb },
             { .name = "change_pwd", .activate = change_password_cb },
             { .name = "edit_row", .activate = edit_selected_row_cb },
             { .name = "settings", .activate = settings_dialog_cb },
@@ -357,7 +358,7 @@ change_password_cb (GSimpleAction *simple    __attribute__((unused)),
 {
     AppData *app_data = (AppData *)user_data;
     gchar *tmp_key = secure_strdup (app_data->db_data->key);
-    gchar *pwd = prompt_for_password (app_data, tmp_key, NULL);
+    gchar *pwd = prompt_for_password (app_data, tmp_key, NULL, FALSE);
     if (pwd != NULL) {
         app_data->db_data->key = pwd;
         GError *err = NULL;

--- a/src/edit-data.c
+++ b/src/edit-data.c
@@ -74,6 +74,10 @@ show_edit_dialog (EditData *edit_data, AppData *app_data, gchar *current_label, 
     gtk_entry_set_text (GTK_ENTRY(new_lab_entry), current_label);
     gtk_entry_set_text (GTK_ENTRY(new_iss_entry), current_issuer);
 
+    if (g_ascii_strcasecmp (current_issuer, "steam") == 0) {
+        gtk_widget_set_sensitive (new_iss_entry, FALSE);
+    }
+
     gchar *err_msg = NULL;
     gint res = gtk_dialog_run (GTK_DIALOG (diag));
     switch (res) {

--- a/src/exports.c
+++ b/src/exports.c
@@ -1,0 +1,58 @@
+#include <gtk/gtk.h>
+#include <gcrypt.h>
+#include <jansson.h>
+#include "password-cb.h"
+#include "message-dialogs.h"
+#include "gquarks.h"
+#include "db-misc.h"
+#include "exports.h"
+
+
+void
+export_data_cb (GSimpleAction *simple,
+                GVariant      *parameter __attribute__((unused)),
+                gpointer       user_data)
+{
+    const gchar *action_name = g_action_get_name (G_ACTION(simple));
+    AppData *app_data = (AppData *)user_data;
+
+    const gchar *base_dir = NULL;
+#ifndef USE_FLATPAK_APP_FOLDER
+    base_dir = g_get_home_dir ();
+#else
+    base_dir = g_get_user_data_dir ();
+#endif
+
+    gchar *password = prompt_for_password (app_data, NULL, NULL, TRUE);
+
+    gchar *exported_file_path = NULL;
+    if (g_strcmp0 (action_name, "export_andotp") == 0) {
+        exported_file_path = g_build_filename (base_dir, "andotp_exports.json.aes", NULL);
+        gchar *message = NULL;
+        GtkMessageType msg_type;
+        gchar *ret_msg = export_andotp (exported_file_path, password, app_data->db_data->json_data);
+        if (ret_msg != NULL) {
+            message = g_strconcat ("Error while exporting data: ", ret_msg, NULL);
+            msg_type = GTK_MESSAGE_ERROR;
+        } else {
+            message = g_strconcat ("Data successfully exported to ", exported_file_path, NULL);
+            msg_type = GTK_MESSAGE_INFO;
+        }
+        show_message_dialog (app_data->main_window, message, msg_type);
+        g_free (message);
+        g_free (ret_msg);
+    }/* else if (g_strcmp0 (action_name, "export_authy") == 0) {
+        // TODO: check authy format
+        exported_file_path = g_build_filename (base_dir, "", NULL);
+        export_authy (exported_file_path);
+    } else if (g_strcmp0 (action_name, "export_winauth") == 0) {
+        // TODO: check winauth format
+        exported_file_path = g_build_filename (base_dir, "", NULL);
+        export_winauth (exported_file_path);
+    }*/ else {
+        show_message_dialog (app_data->main_window, "Invalid export action.", GTK_MESSAGE_ERROR);
+        return;
+    }
+
+    g_free (exported_file_path);
+}

--- a/src/exports.h
+++ b/src/exports.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include <jansson.h>
+
+G_BEGIN_DECLS
+
+#define ANDOTP_EXPORT_ACTION_NAME   "export_andotp"
+#define AUTHY_EXPORT_ACTION_NAME    "export_authy"
+#define WINAUTH_EXPORT_ACTION_NAME  "export_winauth"
+
+void
+export_data_cb (GSimpleAction *simple,
+                GVariant      *parameter,
+                gpointer       user_data);
+
+gchar *
+export_andotp ( const gchar *export_path,
+                const gchar *password,
+                json_t *json_db_data);
+
+G_END_DECLS

--- a/src/imports.c
+++ b/src/imports.c
@@ -19,11 +19,11 @@ select_file_cb (GSimpleAction *simple,
                 GVariant      *parameter __attribute__((unused)),
                 gpointer       user_data)
 {
-    const gchar *action_name = g_action_get_name (G_ACTION (simple));
+    const gchar *action_name = g_action_get_name (G_ACTION(simple));
     AppData *app_data = (AppData *)user_data;
 
     GtkWidget *dialog = gtk_file_chooser_dialog_new ("Open File",
-                                                     GTK_WINDOW (app_data->main_window),
+                                                     GTK_WINDOW(app_data->main_window),
                                                      GTK_FILE_CHOOSER_ACTION_OPEN,
                                                      "Cancel", GTK_RESPONSE_CANCEL,
                                                      "Open", GTK_RESPONSE_ACCEPT,
@@ -33,9 +33,9 @@ select_file_cb (GSimpleAction *simple,
     gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), g_get_user_data_dir ());
 #endif
 
-    gint res = gtk_dialog_run (GTK_DIALOG (dialog));
+    gint res = gtk_dialog_run (GTK_DIALOG(dialog));
     if (res == GTK_RESPONSE_ACCEPT) {
-        GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);
+        GtkFileChooser *chooser = GTK_FILE_CHOOSER(dialog);
         gchar *filename = gtk_file_chooser_get_filename (chooser);
         parse_data_and_update_db (app_data, filename, action_name);
         g_free (filename);
@@ -54,7 +54,7 @@ update_db_from_otps (GSList *otps, AppData *app_data)
         otp_t *otp = g_slist_nth_data (otps, i);
         obj = build_json_obj (otp->type, otp->label, otp->issuer, otp->secret, otp->digits, otp->algo, otp->period, otp->counter);
         guint hash = json_object_get_hash (obj);
-        if (g_slist_find_custom (app_data->db_data->objects_hash, GUINT_TO_POINTER (hash), check_duplicate) == NULL) {
+        if (g_slist_find_custom (app_data->db_data->objects_hash, GUINT_TO_POINTER(hash), check_duplicate) == NULL) {
             app_data->db_data->objects_hash = g_slist_append (app_data->db_data->objects_hash, g_memdup (&hash, sizeof (guint)));
             app_data->db_data->data_to_add = g_slist_append (app_data->db_data->data_to_add, obj);
         } else {
@@ -97,7 +97,7 @@ parse_data_and_update_db (AppData       *app_data,
 {
     GError *err = NULL;
     GSList *content = NULL;
-    gchar *pwd = prompt_for_password (app_data, NULL, action_name);
+    gchar *pwd = prompt_for_password (app_data, NULL, action_name, FALSE);
     if (pwd == NULL) {
         return FALSE;
     }

--- a/src/imports.h
+++ b/src/imports.h
@@ -5,8 +5,11 @@
 
 G_BEGIN_DECLS
 
-#define ANDOTP_IMPORT_ACTION_NAME "import_andotp"
+#define ANDOTP_IMPORT_ACTION_NAME   "import_andotp"
 #define AUTHPLUS_IMPORT_ACTION_NAME "import_authplus"
+#define AUTHY_IMPORT_ACTION_NAME    "import_authy"
+#define WINAUTH_IMPORT_ACTION_NAME  "import_winauth"
+
 
 typedef struct _otp_t {
     gchar *type;

--- a/src/otpclient.h
+++ b/src/otpclient.h
@@ -5,7 +5,7 @@
 G_BEGIN_DECLS
 
 #define APP_NAME                "OTPClient"
-#define APP_VERSION             "1.4.0-beta"
+#define APP_VERSION             "1.4.0"
 
 #define HOTP_RATE_LIMIT_IN_SEC  3
 

--- a/src/otpclient.h
+++ b/src/otpclient.h
@@ -5,7 +5,7 @@
 G_BEGIN_DECLS
 
 #define APP_NAME                "OTPClient"
-#define APP_VERSION             "1.3.1"
+#define APP_VERSION             "1.4.0-beta"
 
 #define HOTP_RATE_LIMIT_IN_SEC  3
 

--- a/src/password-cb.c
+++ b/src/password-cb.c
@@ -25,9 +25,10 @@ static void password_cb   (GtkWidget *entry,
 
 
 gchar *
-prompt_for_password (AppData *app_data,
-                     gchar *current_key,
-                     const gchar *action_name)
+prompt_for_password (AppData        *app_data,
+                     gchar          *current_key,
+                     const gchar    *action_name,
+                     gboolean        is_export_pwd)
 {
     EntryWidgets *entry_widgets = g_new0 (EntryWidgets, 1);
     entry_widgets->retry = FALSE;
@@ -52,7 +53,7 @@ prompt_for_password (AppData *app_data,
         entry_widgets->entry1 = GTK_WIDGET(gtk_builder_get_object (builder,"decpwddiag_entry_id"));
         g_signal_connect (entry_widgets->entry1, "activate", G_CALLBACK (send_ok_cb), NULL);
         g_signal_connect (entry_widgets->entry1, "icon-press", G_CALLBACK (icon_press_cb), NULL);
-    } else if (file_exists == FALSE && current_key == NULL) {
+    } else if ((file_exists == FALSE && current_key == NULL) || is_export_pwd == TRUE) {
         // new db dialog, 2 fields
         dialog = GTK_WIDGET(gtk_builder_get_object (builder, "newdb_pwd_diag_id"));
         entry_widgets->entry1 = GTK_WIDGET(gtk_builder_get_object (builder,"newdb_pwd_diag_entry1_id"));

--- a/src/password-cb.c
+++ b/src/password-cb.c
@@ -69,6 +69,12 @@ prompt_for_password (AppData        *app_data,
         g_signal_connect (entry_widgets->entry2, "icon-press", G_CALLBACK (icon_press_cb), NULL);
     } else {
         // change pwd dialog, 3 fields
+        if (current_key == NULL) {
+            show_message_dialog (app_data->main_window, "ERROR: current_key cannot be NULL", GTK_MESSAGE_ERROR);
+            g_free (entry_widgets);
+            g_object_unref (builder);
+            return NULL;
+        }
         dialog = GTK_WIDGET(gtk_builder_get_object (builder, "changepwd_diag_id"));
         entry_widgets->cur_pwd = secure_strdup (current_key);
         entry_widgets->entry_old = GTK_WIDGET(gtk_builder_get_object (builder,"changepwd_diag_currententry_id"));

--- a/src/password-cb.c
+++ b/src/password-cb.c
@@ -38,18 +38,24 @@ prompt_for_password (AppData        *app_data,
 
     gboolean pwd_must_be_checked = TRUE;
     gboolean file_exists = g_file_test (app_data->db_data->db_path, G_FILE_TEST_EXISTS);
-    if ((file_exists == TRUE || action_name != NULL) && current_key == NULL) {
+    if ((file_exists == TRUE || action_name != NULL) && current_key == NULL && is_export_pwd == FALSE) {
         // decrypt dialog, just one field
         pwd_must_be_checked = FALSE;
         dialog = GTK_WIDGET(gtk_builder_get_object (builder, "decpwd_diag_id"));
-        gchar *text;
+        gchar *text = NULL, *markup = NULL;
         if (action_name == NULL){
-            text = g_strconcat ("Enter the decryption password for ", app_data->db_data->db_path, NULL);
+            markup = g_markup_printf_escaped ("%s <span font_family=\"monospace\">%s</span>", "Enter the decryption password for ", app_data->db_data->db_path);
         } else {
             text = g_strdup ("Enter the decryption password");
         }
-        gtk_label_set_text (GTK_LABEL(gtk_builder_get_object (builder, "decpwd_label_id")), text);
-        g_free (text);
+        GtkLabel *label = GTK_LABEL(gtk_builder_get_object (builder, "decpwd_label_id"));
+        if (markup != NULL) {
+            gtk_label_set_markup (label, markup);
+            g_free (markup);
+        } else {
+            gtk_label_set_text (label, text);
+            g_free (text);
+        }
         entry_widgets->entry1 = GTK_WIDGET(gtk_builder_get_object (builder,"decpwddiag_entry_id"));
         g_signal_connect (entry_widgets->entry1, "activate", G_CALLBACK (send_ok_cb), NULL);
         g_signal_connect (entry_widgets->entry1, "icon-press", G_CALLBACK (icon_press_cb), NULL);

--- a/src/password-cb.h
+++ b/src/password-cb.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <gtk/gtk.h>
+#include "data.h"
 
 G_BEGIN_DECLS
 
-gchar *prompt_for_password (AppData *app_data, gchar *current_key, const gchar *action_name);
+gchar *prompt_for_password (AppData *app_data, gchar *current_key, const gchar *action_name, gboolean is_export_pwd);
 
 G_END_DECLS

--- a/src/ui/otpclient.ui
+++ b/src/ui/otpclient.ui
@@ -1171,6 +1171,31 @@ Please note that &lt;b&gt;there is no way to recover a forgotten password.&lt;/b
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
+          <object class="GtkModelButton" id="export_andotp_model_btn_id">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="action_name">settings_menu.export_andotp</property>
+            <property name="text" translatable="yes">andOTP</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="submenu">export_menu</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
           <object class="GtkModelButton" id="import_model_btn_id">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -1263,7 +1288,7 @@ Please note that &lt;b&gt;there is no way to recover a forgotten password.&lt;/b
       </object>
       <packing>
         <property name="submenu">main</property>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
   </object>


### PR DESCRIPTION
- add full andOTP support
  - it's now possible to export data into encrypted andOTP format
- use monospace to show the database path on startup
- update readme, license, flatpak, appdata
- fix #119 