### PR TITLE
Switch import dialog from file chooser to native

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -284,17 +284,16 @@ get_db_path (GtkWidget *window)
             return NULL;
         }
     } else {
-        GtkWidget *dialog = gtk_file_chooser_dialog_new ("Select database location",
+        GtkFileChooserNative *dialog = gtk_file_chooser_native_new ("Select database location",
                                                          GTK_WINDOW (window),
                                                          GTK_FILE_CHOOSER_ACTION_SAVE,
-                                                         "Cancel", GTK_RESPONSE_CANCEL,
-                                                         "OK", GTK_RESPONSE_ACCEPT,
-                                                         NULL);
+                                                         "OK",
+                                                         "Cancel");
         GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);
         gtk_file_chooser_set_do_overwrite_confirmation (chooser, TRUE);
         gtk_file_chooser_set_select_multiple (chooser, FALSE);
         gtk_file_chooser_set_current_name (chooser, "NewDatabase.enc");
-        gint res = gtk_dialog_run (GTK_DIALOG (dialog));
+        gint res = gtk_native_dialog_run (GTK_NATIVE_DIALOG(dialog));
         if (res == GTK_RESPONSE_ACCEPT) {
             db_path = gtk_file_chooser_get_filename (chooser);
             g_key_file_set_string (kf, "config", "db_path", db_path);
@@ -304,7 +303,7 @@ get_db_path (GtkWidget *window)
                 g_key_file_free (kf);
             }
         }
-        gtk_widget_destroy (dialog);
+        g_object_unref (dialog);
     }
 
     g_free (cfg_file_path);

--- a/src/imports.c
+++ b/src/imports.c
@@ -22,18 +22,13 @@ select_file_cb (GSimpleAction *simple,
     const gchar *action_name = g_action_get_name (G_ACTION(simple));
     AppData *app_data = (AppData *)user_data;
 
-    GtkWidget *dialog = gtk_file_chooser_dialog_new ("Open File",
+    GtkFileChooserNative *dialog = gtk_file_chooser_native_new ("Open File",
                                                      GTK_WINDOW(app_data->main_window),
                                                      GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                     "Cancel", GTK_RESPONSE_CANCEL,
-                                                     "Open", GTK_RESPONSE_ACCEPT,
-                                                     NULL);
+                                                     "Open",
+                                                     "Cancel");
 
-#ifdef USE_FLATPAK_APP_FOLDER
-    gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), g_get_user_data_dir ());
-#endif
-
-    gint res = gtk_dialog_run (GTK_DIALOG(dialog));
+    gint res = gtk_native_dialog_run (GTK_NATIVE_DIALOG(dialog));
     if (res == GTK_RESPONSE_ACCEPT) {
         GtkFileChooser *chooser = GTK_FILE_CHOOSER(dialog);
         gchar *filename = gtk_file_chooser_get_filename (chooser);
@@ -41,7 +36,7 @@ select_file_cb (GSimpleAction *simple,
         g_free (filename);
     }
 
-    gtk_widget_destroy (dialog);
+    g_object_unref (dialog);
 }
 
 

--- a/src/select-photo-add-cb.c
+++ b/src/select-photo-add-cb.c
@@ -17,28 +17,24 @@ select_photo_cb (GSimpleAction *simple    __attribute__((unused)),
 {
     AppData *app_data = (AppData *)user_data;
 
-    GtkWidget *dialog = gtk_file_chooser_dialog_new ("Open File",
+    GtkFileChooserNative *dialog = gtk_file_chooser_native_new ("Open File",
                                                      GTK_WINDOW (app_data->main_window),
                                                      GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                     "Cancel", GTK_RESPONSE_CANCEL,
-                                                     "Open", GTK_RESPONSE_ACCEPT,
-                                                     NULL);
+                                                     "Open",
+                                                     "Cancel");
 
     GtkFileFilter *filter = gtk_file_filter_new ();
+    gtk_file_filter_set_name (filter, "QR Image (*.png)");
     gtk_file_filter_add_pattern (filter, "*.png");
     gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter);
 
-#ifdef USE_FLATPAK_APP_FOLDER
-    gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), g_get_user_data_dir ());
-#endif
-
-    gint res = gtk_dialog_run (GTK_DIALOG (dialog));
+    gint res = gtk_native_dialog_run (GTK_NATIVE_DIALOG (dialog));
     if (res == GTK_RESPONSE_ACCEPT) {
         gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
         parse_file_and_update_db (filename, app_data);
         g_free (filename);
     }
-    gtk_widget_destroy (dialog);
+    g_object_unref (dialog);
 }
 
 


### PR DESCRIPTION
The main benefit of this is that flatpak can safely import files from
outside of the filesystem sandbox. It also means that the qt file
chooser can be used if preferred.

Edit: Note that the flatpak wiki entry can be changed to remove the following part, if this is merged:

> Because of that, if you want to import a file you have to place it under the aforementioned folder (/home/USER/.var/app/com.github.paolostivanin.OTPClient/data).

Edit 2: Or you can keep that and note that on new enough versions that isn't required.