### PR TITLE
Respect XDG specification when searching for configuration

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -207,7 +207,7 @@ get_config_data (gint     *width,
     GKeyFile *kf = g_key_file_new ();
     gchar *cfg_file_path;
 #ifndef USE_FLATPAK_APP_FOLDER
-    cfg_file_path = g_build_filename (g_get_home_dir (), ".config", "otpclient.cfg", NULL);
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
 #else
     cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
 #endif
@@ -291,7 +291,7 @@ get_db_path (GtkWidget *window)
     gchar *db_path = NULL;
     GError *err = NULL;
     GKeyFile *kf = g_key_file_new ();
-    gchar *cfg_file_path = g_build_filename (g_get_home_dir (), ".config", "otpclient.cfg", NULL);
+    gchar *cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
     if (g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
         if (!g_key_file_load_from_file (kf, cfg_file_path, G_KEY_FILE_NONE, &err)) {
             show_message_dialog (window, err->message, GTK_MESSAGE_ERROR);
@@ -471,7 +471,7 @@ save_window_size (gint width,
     GKeyFile *kf = g_key_file_new ();
     gchar *cfg_file_path;
 #ifndef USE_FLATPAK_APP_FOLDER
-    cfg_file_path = g_build_filename (g_get_home_dir (), ".config", "otpclient.cfg", NULL);
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
 #else
     cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
 #endif

--- a/src/settings.c
+++ b/src/settings.c
@@ -12,7 +12,7 @@ settings_dialog_cb (GSimpleAction *simple    __attribute__((unused)),
 
     gchar *cfg_file_path;
 #ifndef USE_FLATPAK_APP_FOLDER
-    cfg_file_path = g_build_filename (g_get_home_dir (), ".config", "otpclient.cfg", NULL);
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
 #else
     cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
 #endif


### PR DESCRIPTION
Use g_get_user_config_dir which returns XDG_CONFIG_HOME if defined,
otherwise it returns the default value which is $HOME/.config

resolves #139

Tested on Alpine Linux x86_64 with XDG_CONFIG_HOME set, will most likely cause breakage for people that have XDG_CONFIG_HOME defined but have the file in $HOME/.config