### PR TITLE
Fix label, account and issuer

### DIFF
--- a/src/add-common.c
+++ b/src/add-common.c
@@ -39,7 +39,7 @@ static gchar *
 check_params (GSList *otps)
 {
     otp_t *otp = g_slist_nth_data (otps, 0);
-    if (otp->label == NULL) {
+    if (otp->account_name == NULL) {
         return g_strdup ("Label can not be empty, otp not imported");
     }
 
@@ -49,7 +49,7 @@ check_params (GSList *otps)
 
     if (g_ascii_strcasecmp (otp->type, "TOTP") == 0) {
         if (otp->period < 10 || otp->period > 120) {
-            gchar *msg = g_strconcat("[INFO]: invalid period for '", otp->label, "'. Defaulting back to 30 seconds.", NULL);
+            gchar *msg = g_strconcat("[INFO]: invalid period for '", otp->account_name, "'. Defaulting back to 30 seconds.", NULL);
             g_printerr ("%s\n", msg);
             otp->period = 30;
         }

--- a/src/andotp.c
+++ b/src/andotp.c
@@ -122,6 +122,7 @@ export_andotp ( const gchar *export_path,
             json_object_set (export_obj, "type", json_object_get (db_obj, "type"));
         }
 
+        // FIXME: issuer might be empty
         gchar *constructed_label = g_strconcat (json_string_value (json_object_get (db_obj, "issuer")),
                                                 " - ",
                                                 json_string_value (json_object_get (db_obj, "label")),
@@ -227,13 +228,13 @@ parse_json_data (const gchar *data,
         otp_t *otp = g_new0 (otp_t, 1);
         otp->secret = secure_strdup (json_string_value (json_object_get (obj, "secret")));
 
-        const gchar *label_with_issuer = json_string_value (json_object_get (obj, "label"));
-        gchar **tokens = g_strsplit (label_with_issuer, "-", -1);
+        const gchar *account_with_issuer = json_string_value (json_object_get (obj, "label"));
+        gchar **tokens = g_strsplit (account_with_issuer, "-", -1);
         if (tokens[0] && tokens[1]) {
             otp->issuer = g_strdup (g_strstrip (tokens[0]));
-            otp->label = g_strdup (g_strstrip (tokens[1]));
+            otp->account_name = g_strdup (g_strstrip (tokens[1]));
         } else {
-            otp->label = g_strdup (g_strstrip (tokens[0]));
+            otp->account_name = g_strdup (g_strstrip (tokens[0]));
         }
         g_strfreev (tokens);
 

--- a/src/andotp.c
+++ b/src/andotp.c
@@ -122,11 +122,16 @@ export_andotp ( const gchar *export_path,
             json_object_set (export_obj, "type", json_object_get (db_obj, "type"));
         }
 
-        // FIXME: issuer might be empty
-        gchar *constructed_label = g_strconcat (json_string_value (json_object_get (db_obj, "issuer")),
-                                                ":",
-                                                json_string_value (json_object_get (db_obj, "label")),
-                                                NULL);
+        gchar *constructed_label;
+        const gchar *issuer_from_db = json_string_value (json_object_get (db_obj, "issuer"));
+        if (issuer_from_db != NULL && g_utf8_strlen (issuer_from_db, -1) > 0) {
+            constructed_label = g_strconcat (json_string_value (json_object_get (db_obj, "issuer")),
+                                            ":",
+                                            json_string_value (json_object_get (db_obj, "label")),
+                                            NULL);
+        } else {
+            constructed_label = g_strdup (json_string_value (json_object_get (db_obj, "label")));
+        }
         json_object_set (export_obj, "label", json_string (constructed_label));
         g_free (constructed_label);
         json_object_set (export_obj, "secret", json_object_get (db_obj, "secret"));

--- a/src/andotp.c
+++ b/src/andotp.c
@@ -124,7 +124,7 @@ export_andotp ( const gchar *export_path,
 
         // FIXME: issuer might be empty
         gchar *constructed_label = g_strconcat (json_string_value (json_object_get (db_obj, "issuer")),
-                                                " - ",
+                                                ":",
                                                 json_string_value (json_object_get (db_obj, "label")),
                                                 NULL);
         json_object_set (export_obj, "label", json_string (constructed_label));
@@ -229,7 +229,7 @@ parse_json_data (const gchar *data,
         otp->secret = secure_strdup (json_string_value (json_object_get (obj, "secret")));
 
         const gchar *account_with_issuer = json_string_value (json_object_get (obj, "label"));
-        gchar **tokens = g_strsplit (account_with_issuer, "-", -1);
+        gchar **tokens = g_strsplit (account_with_issuer, ":", -1);
         if (tokens[0] && tokens[1]) {
             otp->issuer = g_strdup (g_strstrip (tokens[0]));
             otp->account_name = g_strdup (g_strstrip (tokens[1]));

--- a/src/imports.c
+++ b/src/imports.c
@@ -88,7 +88,7 @@ free_otps_gslist (GSList *otps,
         otp_data = g_slist_nth_data (otps, i);
         g_free (otp_data->type);
         g_free (otp_data->algo);
-        g_free (otp_data->label);
+        g_free (otp_data->account_name);
         g_free (otp_data->issuer);
         gcry_free (otp_data->secret);
     }

--- a/src/imports.c
+++ b/src/imports.c
@@ -59,7 +59,7 @@ update_db_from_otps (GSList *otps, AppData *app_data)
     guint list_len = g_slist_length (otps);
     for (guint i = 0; i < list_len; i++) {
         otp_t *otp = g_slist_nth_data (otps, i);
-        obj = build_json_obj (otp->type, otp->label, otp->issuer, otp->secret, otp->digits, otp->algo, otp->period, otp->counter);
+        obj = build_json_obj (otp->type, otp->account_name, otp->issuer, otp->secret, otp->digits, otp->algo, otp->period, otp->counter);
         guint hash = json_object_get_hash (obj);
         if (g_slist_find_custom (app_data->db_data->objects_hash, GUINT_TO_POINTER(hash), check_duplicate) == NULL) {
             app_data->db_data->objects_hash = g_slist_append (app_data->db_data->objects_hash, g_memdup (&hash, sizeof (guint)));

--- a/src/imports.h
+++ b/src/imports.h
@@ -23,7 +23,7 @@ typedef struct _otp_t {
         guint64 counter;
     };
 
-    gchar *label;
+    gchar *account_name;
 
     gchar *issuer;
 

--- a/src/parse-uri.c
+++ b/src/parse-uri.c
@@ -75,10 +75,10 @@ parse_parameters (const gchar   *modified_uri,
 
     tokens = g_strsplit (escaped_issuer_and_label, ":", -1);
     if (tokens[0] && tokens[1]) {
-        otp->issuer = g_strdup (tokens[0]);
-        otp->account_name = g_strdup (tokens[1]);
+        otp->issuer = g_strdup (g_strstrip (tokens[0]));
+        otp->account_name = g_strdup (g_strstrip (tokens[1]));
     } else {
-        otp->account_name = g_strdup (tokens[0]);
+        otp->account_name = g_strdup (g_strstrip (tokens[0]));
     }
     g_free (escaped_issuer_and_label);
     g_strfreev (tokens);
@@ -109,7 +109,7 @@ parse_parameters (const gchar   *modified_uri,
         } else if (g_ascii_strncasecmp (tokens[i], "issuer=", 7) == 0) {
             tokens[i] += 7;
             if (!otp->issuer) {
-                otp->issuer = g_strdup (tokens[i]);
+                otp->issuer = g_strdup (g_strstrip (tokens[i]));
             }
             tokens[i] -= 7;
         } else if (g_ascii_strncasecmp (tokens[i], "counter=", 8) == 0) {

--- a/src/parse-uri.c
+++ b/src/parse-uri.c
@@ -76,9 +76,9 @@ parse_parameters (const gchar   *modified_uri,
     tokens = g_strsplit (escaped_issuer_and_label, ":", -1);
     if (tokens[0] && tokens[1]) {
         otp->issuer = g_strdup (tokens[0]);
-        otp->label = g_strdup (tokens[1]);
+        otp->account_name = g_strdup (tokens[1]);
     } else {
-        otp->label = g_strdup (tokens[0]);
+        otp->account_name = g_strdup (tokens[0]);
     }
     g_free (escaped_issuer_and_label);
     g_strfreev (tokens);

--- a/src/treeview.c
+++ b/src/treeview.c
@@ -238,7 +238,7 @@ add_columns (GtkTreeView *tree_view)
     gtk_tree_view_append_column (tree_view, column);
 
     renderer = gtk_cell_renderer_text_new ();
-    column = gtk_tree_view_column_new_with_attributes ("Label", renderer, "text", COLUMN_ACC_LABEL, NULL);
+    column = gtk_tree_view_column_new_with_attributes ("Account", renderer, "text", COLUMN_ACC_LABEL, NULL);
     gtk_tree_view_column_set_sizing (GTK_TREE_VIEW_COLUMN (column), GTK_TREE_VIEW_COLUMN_AUTOSIZE);
     gtk_tree_view_append_column (tree_view, column);
 

--- a/src/ui/otpclient.ui
+++ b/src/ui/otpclient.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 
 
-Copyright (C) 2018
+Copyright (C) 2019
 
 This file is part of OTPClient.
 
@@ -26,7 +26,7 @@ Author: Paolo Stivanin
   <!-- interface-license-type gplv3 -->
   <!-- interface-name OTPClient -->
   <!-- interface-description Highly secure and easy to use GTK+ OTP client -->
-  <!-- interface-copyright 2018 -->
+  <!-- interface-copyright 2019 -->
   <!-- interface-authors Paolo Stivanin -->
   <object class="GtkPopoverMenu" id="add_pop_id">
     <property name="can_focus">False</property>
@@ -448,7 +448,7 @@ has been found or after 30 seconds if nothing has been detected.</property>
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Please note that "label" is &lt;b&gt;mandatory&lt;/b&gt; and "issuer", while optional,
+            <property name="label" translatable="yes">Please note that "account" is &lt;b&gt;mandatory&lt;/b&gt; and "issuer", while optional,
 is &lt;b&gt;highly recommended&lt;/b&gt;</property>
             <property name="use_markup">True</property>
             <property name="justify">center</property>
@@ -491,7 +491,7 @@ is &lt;b&gt;highly recommended&lt;/b&gt;</property>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">New label</property>
+                    <property name="label" translatable="yes">New account</property>
                   </object>
                 </child>
               </object>
@@ -681,7 +681,7 @@ is &lt;b&gt;highly recommended&lt;/b&gt;</property>
                 <property name="can_focus">True</property>
                 <property name="max_length">64</property>
                 <property name="primary_icon_tooltip_text" translatable="yes">Label</property>
-                <property name="placeholder_text" translatable="yes">Label</property>
+                <property name="placeholder_text" translatable="yes">Account</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -1091,7 +1091,7 @@ Please note that &lt;b&gt;there is no way to recover a forgotten password.&lt;/b
                 <property name="active">0</property>
                 <property name="active_id">0</property>
                 <items>
-                  <item id="0" translatable="yes">Label</item>
+                  <item id="0" translatable="yes">Account</item>
                   <item id="1" translatable="yes">Issuer</item>
                 </items>
               </object>


### PR DESCRIPTION
- Fix andOTP import and export by using the correct separator between account and issuer (`:` instead of ` - `)
- Rename `label` to `account`

This fixes #136 