### PR TITLE
Show correct code when sorting the view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(OTPClient VERSION "2.3.1" LANGUAGES "C")
+project(OTPClient VERSION "2.3.2" LANGUAGES "C")
 
 configure_file("src/common/version.h.in" "version.h")
 include_directories(${PROJECT_BINARY_DIR})

--- a/data/com.github.paolostivanin.OTPClient.appdata.xml
+++ b/data/com.github.paolostivanin.OTPClient.appdata.xml
@@ -83,6 +83,14 @@ It's also possible to import/export backups from/to andOTP and import backups fr
   </content_rating>
 
   <releases>
+    <release version="2.3.2" date="2020-06-xx">
+      <description>
+        <p>OTPClient 2.3.2 brings a small fix</p>
+        <ul>
+          <li>fix incorrect code is shown when sorting by label/issuer</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.3.1" date="2020-05-13">
       <description>
         <p>OTPClient 2.3.1 brings a security fix</p>

--- a/src/liststore-misc.c
+++ b/src/liststore-misc.c
@@ -18,11 +18,16 @@ typedef struct _otp_data {
     gboolean steam;
 } OtpData;
 
-static void set_otp_data (OtpData *otp_data, AppData *app_data, guint row_number);
+static void     set_otp_data                (OtpData *otp_data,
+                                             AppData *app_data,
+                                             gint     row_db_pos);
 
-static gboolean foreach_func_update_otps (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer user_data);
+static gboolean foreach_func_update_otps    (GtkTreeModel *model,
+                                             GtkTreePath *path,
+                                             GtkTreeIter *iter,
+                                             gpointer user_data);
 
-static void clean_otp_data (OtpData *otp_data);
+static void     clean_otp_data              (OtpData *otp_data);
 
 
 gboolean
@@ -42,9 +47,10 @@ set_otp (GtkListStore   *list_store,
 {
     OtpData *otp_data = g_new0 (OtpData, 1);
 
-    guint row_number = get_row_number_from_iter (list_store, iter);
+    gint row_db_pos;
+    gtk_tree_model_get (GTK_TREE_MODEL(list_store), &iter, COLUMN_POSITION_IN_DB, &row_db_pos, -1);
 
-    set_otp_data (otp_data, app_data, row_number);
+    set_otp_data (otp_data, app_data, row_db_pos);
 
     gint algo = get_algo_int_from_str (otp_data->algo);
 
@@ -130,9 +136,9 @@ foreach_func_update_otps (GtkTreeModel *model,
 static void
 set_otp_data (OtpData  *otp_data,
               AppData  *app_data,
-              guint     row_number)
+              gint      row_db_pos)
 {
-    json_t *obj = json_array_get (app_data->db_data->json_data, row_number);
+    json_t *obj = json_array_get (app_data->db_data->json_data, row_db_pos);
 
     otp_data->type = g_strdup (json_string_value (json_object_get (obj, "type")));
     otp_data->secret = secure_strdup (json_string_value (json_object_get (obj, "secret")));

--- a/src/treeview.c
+++ b/src/treeview.c
@@ -222,7 +222,9 @@ reset_column_sorting_cb (GSimpleAction *simple    __attribute__((unused)),
     // set default sorting value
     gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE(GTK_LIST_STORE(gtk_tree_view_get_model (app_data->tree_view))), -2, 0);
 
-    show_message_dialog (app_data->main_window, "Sorting order has been correctly reset.\nPlease close and open the program again to apply the changes.", GTK_MESSAGE_INFO);
+    update_model (app_data);
+
+    show_message_dialog (app_data->main_window, "Sorting order has been correctly reset.", GTK_MESSAGE_INFO);
 }
 
 
@@ -314,14 +316,12 @@ add_columns (GtkTreeView *tree_view)
     renderer = gtk_cell_renderer_text_new ();
     column = gtk_tree_view_column_new_with_attributes ("Account", renderer, "text", COLUMN_ACC_LABEL, NULL);
     gtk_tree_view_column_set_sizing (GTK_TREE_VIEW_COLUMN(column), GTK_TREE_VIEW_COLUMN_AUTOSIZE);
-    gtk_tree_view_column_set_clickable (GTK_TREE_VIEW_COLUMN(column), TRUE);
     gtk_tree_view_column_set_sort_column_id (GTK_TREE_VIEW_COLUMN(column), 1); // 1 is the account column
     gtk_tree_view_append_column (tree_view, column);
 
     renderer = gtk_cell_renderer_text_new ();
     column = gtk_tree_view_column_new_with_attributes ("Issuer", renderer, "text", COLUMN_ACC_ISSUER, NULL);
     gtk_tree_view_column_set_sizing (GTK_TREE_VIEW_COLUMN(column), GTK_TREE_VIEW_COLUMN_AUTOSIZE);
-    gtk_tree_view_column_set_clickable (GTK_TREE_VIEW_COLUMN(column), TRUE);
     gtk_tree_view_column_set_sort_column_id (GTK_TREE_VIEW_COLUMN(column), 2); // 2 is the issuer column
     gtk_tree_view_append_column (tree_view, column);
 


### PR DESCRIPTION
This fixes #181 , but do not fix the issue that entries get duplicated when sorted.
This seems to be related to the treeview itself, and not to OTPClient. I'm looking into a workaround though.