### PR TITLE
Allow user to specify an output folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(OTPClient VERSION "2.4.0" LANGUAGES "C")
+project(OTPClient VERSION "2.4.1" LANGUAGES "C")
 
 configure_file("src/common/version.h.in" "version.h")
 include_directories(${PROJECT_BINARY_DIR})

--- a/data/com.github.paolostivanin.OTPClient.appdata.xml
+++ b/data/com.github.paolostivanin.OTPClient.appdata.xml
@@ -83,7 +83,15 @@ It's also possible to import/export backups from/to andOTP and import backups fr
   </content_rating>
 
   <releases>
-    <release version="2.3.2" date="2020-06-xx">
+    <release version="2.4.1" date="2020-12-31">
+      <description>
+        <p>OTPClient 2.4.1 bring a new feature to the CLI</p>
+        <ul>
+          <li>add export command to otpclient-cli</li>
+        </ul>
+      </description>
+    </release>
+    <release version="2.3.2" date="2020-07-24">
       <description>
         <p>OTPClient 2.3.2 brings a small fix and a new icon</p>
         <ul>

--- a/flatpak/com.github.paolostivanin.OTPClient.yaml
+++ b/flatpak/com.github.paolostivanin.OTPClient.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.paolostivanin.OTPClient
 runtime: org.gnome.Platform
-runtime-version: '3.36'
+runtime-version: '3.38'
 sdk: org.gnome.Sdk
 command: otpclient
 finish-args:
@@ -36,8 +36,8 @@ modules:
   - "/lib/*.la"
   sources:
   - type: archive
-    url: https://libzip.org/download/libzip-1.6.1.tar.xz
-    sha256: 705dac7a671b3f440181481e607b0908129a9cf1ddfcba75d66436c0e7d33641
+    url: https://libzip.org/download/libzip-1.7.3.tar.xz
+    sha256: a60473ffdb7b4260c08bfa19c2ccea0438edac11193c3afbbb1f17fbcf6c6132
 - name: jansson
   cleanup:
   - "/include"

--- a/src/cli/help.c
+++ b/src/cli/help.c
@@ -47,7 +47,7 @@ print_main_help (const gchar *prg_name)
     g_print ("  -v, --version\t\t\t\tShow program version\n");
     g_print ("  show <-a ..> [-i ..] [-m] [-n]\tShow a token\n");
     g_print ("  list\t\t\t\t\tList all pairs of account and issuer\n");
-    g_print ("  export <-t ..>\t\t\tExport data\n");
+    g_print ("  export <-t ..> [-d ..]\t\tExport data\n");
     g_print ("\n");
 }
 
@@ -69,10 +69,11 @@ print_show_help (const gchar *prg_name)
 static void
 print_export_help (const gchar *prg_name)
 {
-    g_print ("Usage:\n  %s export <-t> <andotp [-e] | freeotpplus | aegis>\n", prg_name);
+    g_print ("Usage:\n  %s export <-t> <andotp | freeotpplus | aegis> [-d ..]\n", prg_name);
     g_print ("\n");
     g_print ("Export Options:\n");
-    g_print ("  -t, --type\t\tExport format. Must be either one of: andotp, freeotpplus, aegis\n");
-    g_print ("  -e, --encrypt\t\tOnly with andotp. If specified, the output file will be encrypted.\n");
+    g_print ("  -t, --type\t\tExport format. Must be either one of: andotp_plain, andotp_encrypted, freeotpplus, aegis\n");
+    g_print ("  -d, --directory\tThe output directory where the exported file will be saved.\n");
+    g_print ("\t\t\tIf nothing is specified OR flatpak is being used, the output folder will be the user's HOME directory.\n");
     g_print ("\n");
 }


### PR DESCRIPTION
When using the CLI, it's now possible to specify an output folder by using `-d ..`
If nothing is specified or the location is wrong/doesn't exist, then the default value (home dir) will be used