### PR TITLE
Increase input length limit of secret field in manual dialog

### DIFF
--- a/src/ui/otpclient.ui
+++ b/src/ui/otpclient.ui
@@ -926,7 +926,7 @@ is &lt;b&gt;highly recommended&lt;/b&gt;</property>
               <object class="GtkEntry" id="manual_diag_secret_entry_id">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="max_length">96</property>
+                <property name="max_length">255</property>
                 <property name="visibility">False</property>
                 <property name="secondary_icon_name">dialog-password-symbolic</property>
                 <property name="primary_icon_tooltip_text" translatable="yes">Secret</property>


### PR DESCRIPTION
The previous limit was too restrictive in some instances.

RFC 6238 doesn't actually specify a hard length limit for the secret.

---

I found this problem while trying to setup 2FA on https://bethesda.net.

From https://tools.ietf.org/html/rfc6238#section-5.1 (emphasis mine):

> Keys **SHOULD** be of the length of the HMAC output to facilitate
   interoperability.

`SHOULD`, not `MUST`, so technically there is no limit.

Disclaimer: I did not even try to compile and test with this change, just trying a "quick and dirty" fix. I'm not that familiar with GTK applications, but this seemed enough to make it work. Let me know if more changes are needed.
