### PR TITLE
Manual installation documentation tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Highly secure and easy to use GTK+ software for two-factor authentication that s
 |libpng|1.2.0|-|
 |[libcotp](https://github.com/paolostivanin/libcotp)|1.2.1|-|
 |zbar|0.10|0.20 ([linuxtv](https://linuxtv.org/downloads/zbar/))|
+|cmake|3.5|-|
 
 ## Features
 - support both TOTP and HOTP
@@ -43,12 +44,12 @@ If OTPClient hasn't been packaged for your distro ([check here](https://github.c
 1. install all the needed libraries listed under [requirements](#requirements)
 2. clone and install OTPClient:
 ```
-$ git clone https://github.com/paolostivanin/OTPClient.git
-$ cd OTPClient
-$ mkdir build && cd $_
-$ cmake -DCMAKE_INSTALL_PREFIX=/usr ..
-$ make
-$ sudo make install
+git clone https://github.com/paolostivanin/OTPClient.git
+cd OTPClient
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+make
+sudo make install
 ```
 
 ## License


### PR DESCRIPTION
Just a minor doc improvement proposal, this would:
- Add cmake to the build requirements
- Remove the `$` decorations in the build snippet (they make it tedious to copy instructions to the terminal)
- Change `mkdir build && cd $_` into `mkdir build && cd build` - on my shell (fish) the former does not work, the latter should work everywhere

Thank you for your work and for sharing OTPClient with the world!