### PR TITLE
Fix andotp

### DIFF
--- a/src/common/aegis.c
+++ b/src/common/aegis.c
@@ -5,6 +5,7 @@
 #include "../imports.h"
 #include "../gui-common.h"
 #include "../gquarks.h"
+#include "common.h"
 
 
 static GSList *parse_json_data                (const gchar          *data,
@@ -173,7 +174,7 @@ parse_json_data (const gchar *data,
             return NULL;
         }
 
-        otps = g_slist_append (otps, g_memdup (otp, sizeof (otp_t)));
+        otps = g_slist_append (otps, g_memdupX (otp, sizeof (otp_t)));
         g_free (otp);
     }
 

--- a/src/common/andotp.c
+++ b/src/common/andotp.c
@@ -317,7 +317,9 @@ parse_json_data (const gchar *data,
         otp->secret = secure_strdup (json_string_value (json_object_get (obj, "secret")));
 
         const gchar *issuer = json_string_value (json_object_get (obj, "issuer"));
-        otp->issuer = g_strstrip (g_strdup (issuer));
+        if (issuer != NULL && g_utf8_strlen (issuer, -1) > 1) {
+            otp->issuer = g_strstrip (g_strdup (issuer));
+        }
 
         const gchar *label_with_prefix = json_string_value (json_object_get (obj, "label"));
         gchar **tokens = g_strsplit (label_with_prefix, ":", -1);
@@ -325,7 +327,8 @@ parse_json_data (const gchar *data,
             if (issuer != NULL && g_ascii_strcasecmp(issuer, tokens[0]) == 0) {
                 otp->account_name = g_strstrip (g_strdup (tokens[1]));
             } else {
-                otp->account_name = g_strstrip (g_strdup (label_with_prefix));
+                otp->issuer = g_strstrip (g_strdup (tokens[0]));
+                otp->account_name = g_strstrip (g_strdup (tokens[1]));
             }
         } else {
             otp->account_name = g_strstrip (g_strdup (tokens[0]));

--- a/src/common/andotp.c
+++ b/src/common/andotp.c
@@ -7,6 +7,7 @@
 #include "../imports.h"
 #include "../gui-common.h"
 #include "../gquarks.h"
+#include "common.h"
 
 #define ANDOTP_IV_SIZE   12
 #define ANDOTP_SALT_SIZE 12
@@ -374,7 +375,7 @@ parse_json_data (const gchar *data,
             return NULL;
         }
 
-        otps = g_slist_append (otps, g_memdup (otp, sizeof (otp_t)));
+        otps = g_slist_append (otps, g_memdupX (otp, sizeof (otp_t)));
         g_free (otp);
     }
 

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -5,6 +5,12 @@
 
 G_BEGIN_DECLS
 
+#if GLIB_CHECK_VERSION(2, 68, 0)
+    #define g_memdupX g_memdup2
+#else
+    #define g_memdupX g_memdup
+#endif
+
 gint32      get_max_file_size_from_memlock  (void);
 
 gchar      *init_libs                       (gint32 max_file_size);

--- a/src/db-misc.c
+++ b/src/db-misc.c
@@ -69,7 +69,7 @@ load_db (DatabaseData    *db_data,
     json_t *obj;
     json_array_foreach (db_data->json_data, index, obj) {
         guint32 hash = json_object_get_hash (obj);
-        db_data->objects_hash = g_slist_append (db_data->objects_hash, g_memdup (&hash, sizeof (guint32)));
+        db_data->objects_hash = g_slist_append (db_data->objects_hash, g_memdupX (&hash, sizeof (guint32)));
     }
 }
 

--- a/src/imports.c
+++ b/src/imports.c
@@ -66,7 +66,7 @@ update_db_from_otps (GSList *otps, AppData *app_data)
         obj = build_json_obj (otp->type, otp->account_name, otp->issuer, otp->secret, otp->digits, otp->algo, otp->period, otp->counter);
         guint hash = json_object_get_hash (obj);
         if (g_slist_find_custom (app_data->db_data->objects_hash, GUINT_TO_POINTER(hash), check_duplicate) == NULL) {
-            app_data->db_data->objects_hash = g_slist_append (app_data->db_data->objects_hash, g_memdup (&hash, sizeof (guint)));
+            app_data->db_data->objects_hash = g_slist_append (app_data->db_data->objects_hash, g_memdupX (&hash, sizeof (guint)));
             app_data->db_data->data_to_add = g_slist_append (app_data->db_data->data_to_add, obj);
         } else {
             g_print ("[INFO] Duplicate element not added\n");

--- a/src/parse-data.c
+++ b/src/parse-data.c
@@ -51,7 +51,7 @@ parse_user_data (Widgets        *widgets,
         obj = get_json_obj (widgets, acc_label, acc_iss, acc_key, digits, period, counter);
         guint32 hash = json_object_get_hash (obj);
         if (g_slist_find_custom (db_data->objects_hash, GUINT_TO_POINTER (hash), check_duplicate) == NULL) {
-            db_data->objects_hash = g_slist_append (db_data->objects_hash, g_memdup (&hash, sizeof (guint)));
+            db_data->objects_hash = g_slist_append (db_data->objects_hash, g_memdupX (&hash, sizeof (guint)));
             db_data->data_to_add = g_slist_append (db_data->data_to_add, obj);
         } else {
             g_print ("[INFO] Duplicate element not added\n");

--- a/src/parse-uri.c
+++ b/src/parse-uri.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 #include "gui-common.h"
 #include "imports.h"
+#include "common/common.h"
 
 
 static void parse_uri           (const gchar   *uri,
@@ -59,7 +60,7 @@ parse_uri (const gchar   *uri,
     }
     parse_parameters (uri_copy, otp);
 
-    *otps = g_slist_append (*otps, g_memdup (otp, sizeof (otp_t)));
+    *otps = g_slist_append (*otps, g_memdupX (otp, sizeof (otp_t)));
     g_free (otp);
 }
 


### PR DESCRIPTION
* Import was not working correctly since the format in andOTP's db has changed.
Now tokens are imported with the correct account/issuer order.
* use `g_memdup2` instead of the deprecated `g_memdup`