### PR TITLE
Trim whitespace when parsing account secret

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -98,3 +98,18 @@ json_object_get_hash (json_t *obj)
 
     return hash;
 }
+
+void
+g_trim_whitespace (gchar *str)
+{
+    if (g_utf8_strlen (str, -1) == 0) {
+        return;
+    }
+    int pos = 0;
+    for (int i = 0; str[i]; i++) {
+        if (str[i] != ' ') {
+            str[pos++] = str[i];
+        }
+    }
+    str[pos] = '\0';
+}

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -16,4 +16,6 @@ guint32     jenkins_one_at_a_time_hash      (const gchar    *key,
 
 guint32     json_object_get_hash            (json_t *obj);
 
+void        g_trim_whitespace               (gchar *str);
+
 G_END_DECLS

--- a/src/parse-data.c
+++ b/src/parse-data.c
@@ -47,6 +47,7 @@ parse_user_data (Widgets        *widgets,
     const gchar *counter = gtk_entry_get_text (GTK_ENTRY (widgets->counter_entry));
     gboolean period_active = gtk_widget_get_sensitive (widgets->period_entry);
     gboolean counter_active = gtk_widget_get_sensitive (widgets->counter_entry);
+    g_trim_whitespace (acc_key);
     if (is_input_valid (widgets->dialog, acc_label, acc_iss, acc_key, digits, period, period_active, counter, counter_active)) {
         obj = get_json_obj (widgets, acc_label, acc_iss, acc_key, digits, period, counter);
         guint32 hash = json_object_get_hash (obj);


### PR DESCRIPTION
Hey there, thanks for the nice work on this tool!

This one fixes the issue with secret keys which contain spaces.
One had to manually delete the space characters from every secret key in cleartext mode. This was time consuming if one experiments with rotating secrets a lot and was also irritating for new users which just pasted the keys without knowing which characters were "bad".

Fixes #212 