### PR TITLE
Small fixes

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -99,17 +99,31 @@ json_object_get_hash (json_t *obj)
     return hash;
 }
 
-void
-g_trim_whitespace (gchar *str)
+gchar *
+secure_strdup (const gchar *src)
+{
+    gchar *sec_buf = gcry_calloc_secure (strlen (src) + 1, 1);
+    memcpy (sec_buf, src, strlen (src) + 1);
+
+    return sec_buf;
+}
+
+
+gchar *
+g_trim_whitespace (const gchar *str)
 {
     if (g_utf8_strlen (str, -1) == 0) {
-        return;
+        return NULL;
     }
+    gchar *sec_buf = gcry_calloc_secure (strlen (str) + 1, 1);
     int pos = 0;
     for (int i = 0; str[i]; i++) {
         if (str[i] != ' ') {
-            str[pos++] = str[i];
+            sec_buf[pos++] = str[i];
         }
     }
-    str[pos] = '\0';
+    sec_buf[pos] = '\0';
+    gcry_realloc (sec_buf, g_utf8_strlen(sec_buf, -1) + 1);
+
+    return sec_buf;
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -22,6 +22,8 @@ guint32     jenkins_one_at_a_time_hash      (const gchar    *key,
 
 guint32     json_object_get_hash            (json_t *obj);
 
-void        g_trim_whitespace               (gchar *str);
+gchar      *secure_strdup                   (const gchar    *src);
+
+gchar      *g_trim_whitespace               (const gchar *str);
 
 G_END_DECLS

--- a/src/gui-common.c
+++ b/src/gui-common.c
@@ -26,16 +26,6 @@ get_row_number_from_iter (GtkListStore *list_store,
 }
 
 
-gchar *
-secure_strdup (const gchar *src)
-{
-    gchar *sec_buf = gcry_calloc_secure (strlen (src) + 1, 1);
-    memcpy (sec_buf, src, strlen (src) + 1);
-
-    return sec_buf;
-}
-
-
 json_t *
 build_json_obj (const gchar *type,
                 const gchar *acc_label,

--- a/src/gui-common.h
+++ b/src/gui-common.h
@@ -13,8 +13,6 @@ void         icon_press_cb              (GtkEntry       *entry,
 guint        get_row_number_from_iter   (GtkListStore   *list_store,
                                          GtkTreeIter     iter);
 
-gchar       *secure_strdup              (const gchar    *src);
-
 json_t      *build_json_obj             (const gchar *type,
                                          const gchar *acc_label,
                                          const gchar *acc_iss,

--- a/src/password-cb.c
+++ b/src/password-cb.c
@@ -4,6 +4,7 @@
 #include "message-dialogs.h"
 #include "get-builder.h"
 #include "otpclient.h"
+#include "common/common.h"
 
 typedef struct _entrywidgets {
     GtkWidget *entry_old;

--- a/src/qrcode-parser.c
+++ b/src/qrcode-parser.c
@@ -3,6 +3,7 @@
 #include <png.h>
 #include <glib/gstdio.h>
 #include "gui-common.h"
+#include "common/common.h"
 
 typedef struct _image_data_t {
     gulong width;

--- a/src/webcam-add-cb.c
+++ b/src/webcam-add-cb.c
@@ -7,6 +7,7 @@
 #include "message-dialogs.h"
 #include "add-common.h"
 #include "get-builder.h"
+#include "common/common.h"
 
 
 typedef struct _config_data {


### PR DESCRIPTION
* check for `NULL` when comparing strings
* use `secure_strdup` when trimming the account key