### PR TITLE
Decode URIs from QR codes

### DIFF
--- a/src/qrcode-parser.c
+++ b/src/qrcode-parser.c
@@ -51,7 +51,7 @@ parse_qrcode (const gchar    *png_path,
 
     const zbar_symbol_t *symbol = zbar_image_first_symbol (image);
     for (; symbol; symbol = zbar_symbol_next (symbol)) {
-        *otpauth_uri = secure_strdup (zbar_symbol_get_data (symbol));
+        *otpauth_uri = secure_strdup (g_uri_unescape_string (zbar_symbol_get_data (symbol), NULL));
     }
 
     zbar_image_destroy (image);

--- a/src/webcam-add-cb.c
+++ b/src/webcam-add-cb.c
@@ -103,7 +103,7 @@ scan_qrcode (zbar_image_t   *image,
     ConfigData *cfg_data = (ConfigData *)user_data;
     const zbar_symbol_t *symbol = zbar_image_first_symbol (image);
     for (; symbol; symbol = zbar_symbol_next (symbol)) {
-        cfg_data->otp_uri = secure_strdup (zbar_symbol_get_data (symbol));
+        cfg_data->otp_uri = secure_strdup (g_uri_unescape_string (zbar_symbol_get_data (symbol), NULL));
         cfg_data->qrcode_found = TRUE;
     }
 }


### PR DESCRIPTION
URIs from the webcam can contain encoded URIs.  These need to be decoded
before they are usable.

Fixes: #228