### PR TITLE
Fix symlinked db malloc bug

### DIFF
--- a/src/file-size.c
+++ b/src/file-size.c
@@ -5,10 +5,9 @@ goffset
 get_file_size (const gchar *file_path)
 {
     GError *error = NULL;
-    GFileQueryInfoFlags flags = G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS;
 
     GFile *file = g_file_new_for_path (file_path);
-    GFileInfo *info = g_file_query_info (G_FILE(file), "standard::*", flags, NULL, &error);
+    GFileInfo *info = g_file_query_info (G_FILE(file), "standard::*", G_FILE_QUERY_INFO_NONE, NULL, &error);
     if (info == NULL) {
         g_printerr ("%s\n", error->message);
         g_clear_error (&error);


### PR DESCRIPTION
When the `db_path` is a symlink, the program crashes:

    mobian@mobian:~$ otpclient-cli list
    Type the DB decryption password:

    (process:1382): GLib-ERROR **: 01:45:25.011: ../../../glib/gmem.c:169: failed to allocate 18446744073709551586 bytes
    Trace/breakpoint trap

`get_file_size()` was returning the size of the symlink, not the size of the linked to database.  This resulted in an unsigned underrun, which presents as that enormous malloc that fails. Not sure if this `G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS` flag is set for a good reason, but this patch fixes the bug for me. :-)

fixes paolostivanin/OTPClient#289