### PR TITLE
Correctly quit the password dialog on export.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(OTPClient VERSION "3.1.5" LANGUAGES "C")
+project(OTPClient VERSION "3.1.6" LANGUAGES "C")
 include(GNUInstallDirs)
 
 configure_file("src/common/version.h.in" "version.h")

--- a/data/com.github.paolostivanin.OTPClient.appdata.xml
+++ b/data/com.github.paolostivanin.OTPClient.appdata.xml
@@ -75,6 +75,14 @@ It's also possible to import/export backups from/to andOTP and import backups fr
   </content_rating>
 
   <releases>
+    <release version="3.1.6" date="2023-03-22">
+      <description>
+        <p>OTPClient 3.1.6 fixes a security issue.</p>
+        <ul>
+          <li>quit the password dialog when either the cancel or close button is pressed</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.1.5" date="2023-03-15">
       <description>
         <p>OTPClient 3.1.5 fixes an issue when dealing with symlink</p>

--- a/src/exports.c
+++ b/src/exports.c
@@ -34,6 +34,9 @@ export_data_cb (GSimpleAction *simple,
     if (g_strcmp0 (action_name, ANDOTP_EXPORT_ACTION_NAME) == 0 || g_strcmp0 (action_name, ANDOTP_EXPORT_PLAIN_ACTION_NAME) == 0) {
         if (encrypted == TRUE) {
             password = prompt_for_password (app_data, NULL, NULL, TRUE);
+            if (password == NULL) {
+                return;
+            }
         }
         exported_file_path = g_build_filename (base_dir, encrypted == TRUE ? "andotp_exports.json.aes" : "andotp_exports.json", NULL);
         ret_msg = export_andotp (exported_file_path, password, app_data->db_data->json_data);
@@ -45,6 +48,9 @@ export_data_cb (GSimpleAction *simple,
     } else if (g_strcmp0 (action_name, AEGIS_EXPORT_ACTION_NAME) == 0 || g_strcmp0 (action_name, AEGIS_EXPORT_PLAIN_ACTION_NAME) == 0) {
         if (encrypted == TRUE) {
             password = prompt_for_password (app_data, NULL, NULL, TRUE);
+            if (password == NULL) {
+                return;
+            }
         }
         exported_file_path = g_build_filename (base_dir, encrypted == TRUE ? "aegis_encrypted.json" : "aegis_export_plain.json", NULL);
         ret_msg = export_aegis (exported_file_path, app_data->db_data->json_data, password);


### PR DESCRIPTION
This avoid dumping the database in plaintext format if the user press either the cancel or close button.