### PR TITLE
Reduce export file permissions and overwrite it

### DIFF
--- a/src/common/aegis.c
+++ b/src/common/aegis.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 #include <gcrypt.h>
 #include <jansson.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <uuid/uuid.h>
 #include "../imports.h"
@@ -372,7 +373,9 @@ export_aegis (const gchar   *export_path,
         gcry_cipher_close (hd);
     }
 
+    mode_t old_umask = umask(S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
     FILE *fp = fopen (export_path, "w");
+    umask(old_umask);
     if (fp == NULL) {
         g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "couldn't create the file object");
     } else {

--- a/src/common/andotp.c
+++ b/src/common/andotp.c
@@ -276,7 +276,7 @@ export_andotp (const gchar *export_path,
     gcry_cipher_close (hd);
 
     GFile *out_gfile = g_file_new_for_path (export_path);
-    GFileOutputStream *out_stream = g_file_append_to (out_gfile, G_FILE_CREATE_REPLACE_DESTINATION, NULL, &err);
+    GFileOutputStream *out_stream = g_file_replace (out_gfile, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, &err);
     if (err != NULL) {
         goto cleanup_before_exiting;
     }

--- a/src/common/freeotp.c
+++ b/src/common/freeotp.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 #include <gcrypt.h>
 #include <jansson.h>
+#include <sys/stat.h>
 #include <time.h>
 #include "../file-size.h"
 #include "../parse-uri.h"
@@ -37,8 +38,9 @@ export_freeotpplus (const gchar *export_path,
 {
     json_t *db_obj;
     gsize index;
-
+    mode_t old_umask = umask(S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
     FILE *fp = fopen (export_path, "w");
+    umask(old_umask);
     if (fp == NULL) {
         return g_strdup ("couldn't create the file object");
     }


### PR DESCRIPTION
Also fixes "append instead of overwrite" bug in andOTP export, mentioned in issue #305