### PR TITLE
Small fixes to memory management

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -742,6 +742,7 @@ destroy_cb (GtkWidget   *window,
     save_window_size (w, h);
     g_object_unref (app_data->builder);
     g_free (app_data);
+    gcry_control (GCRYCTL_TERM_SECMEM);
 }
 
 


### PR DESCRIPTION
* call `GCRYCTL_TERM_SECMEM` when the app closes
* use standard memory instead of secure memory for loading the encrypted json. We don't need to waste secure memory for encrypted stuff.