### PR TITLE
common: ask gcrypt to use the system RNG as source of entropy

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -34,6 +34,7 @@ get_max_file_size_from_memlock (void)
 gchar *
 init_libs (gint32 max_file_size)
 {
+    gcry_control(GCRYCTL_SET_PREFERRED_RNG_TYPE, GCRY_RNG_TYPE_SYSTEM);
     if (!gcry_check_version ("1.8.0")) {
         return g_strdup ("The required version of GCrypt is 1.8.0 or greater.");
     }


### PR DESCRIPTION
By default gcrypt uses an userspace RNG, that simply cannot have all the information it needs to be correct on suspend/resume and other special cases, the kernel does not expose this information to userspace.
Switch to GCRY_RNG_TYPE_SYSTEM, that simple wraps getrandom() on linux.

call to gcry_control must be issued before gcry_check_version.