### PR TITLE
Remove extraneous NULs after newlines in exported FreeOTP files

### DIFF
--- a/src/common/freeotp.c
+++ b/src/common/freeotp.c
@@ -45,7 +45,7 @@ export_freeotpplus (const gchar *export_path,
     if (err == NULL) {
         json_array_foreach (json_db_data, index, db_obj) {
             gchar *uri = get_otpauth_uri (NULL, db_obj);
-            if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), uri, g_utf8_strlen (uri, -1) + 1, NULL, &err) == -1) {
+            if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), uri, g_utf8_strlen (uri, -1), NULL, &err) == -1) {
                 g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "couldn't dump json data to file");
             }
             g_free (uri);


### PR DESCRIPTION
Changes to FreeOTP export code in b6fb69c3b713 caused NULs to be written in the exported file after every newline, which is inconsistent with the format of files produced by prior versions of OTPClient and by FreeOTP+ (version 3.1) itself.

This patch removes the NULs.
