### PR TITLE
Minimize to tray with libindicator

### DIFF
--- a/.ci/install_otpclient_notray.sh
+++ b/.ci/install_otpclient_notray.sh
@@ -3,7 +3,7 @@
 set -e
 
 __compile_and_install() {
-  cmake .. -DENABLE_MINIMIZE_TO_TRAY=ON -DCMAKE_INSTALL_PREFIX=/usr
+  cmake .. -DCMAKE_INSTALL_PREFIX=/usr
   make -j2
   make install
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,21 @@
 version: 2.0
 
 jobs:
-  archlinux:
+  archlinux_notray:
     docker:
       - image: archlinux:latest
     steps:
       - checkout
       - run: pacman -Syu --noconfirm && pacman -S --noconfirm pkg-config git gtk3 libgcrypt zbar gcc clang cmake make libzip jansson libpng protobuf-c libsecret util-linux-libs qrencode
+      - run: chmod +x .ci/install_deps.sh && .ci/install_deps.sh
+      - run: chmod +x .ci/install_otpclient_notray.sh && .ci/install_otpclient_notray.sh
+
+  archlinux:
+    docker:
+      - image: archlinux:latest
+    steps:
+      - checkout
+      - run: pacman -Syu --noconfirm && pacman -S --noconfirm pkg-config git gtk3 libgcrypt zbar gcc clang cmake make libzip jansson libpng protobuf-c libsecret util-linux-libs qrencode libayatana-appindicator
       - run: chmod +x .ci/install_deps.sh && .ci/install_deps.sh
       - run: chmod +x .ci/install_otpclient.sh && .ci/install_otpclient.sh
 
@@ -15,7 +24,7 @@ jobs:
       - image: debian:latest
     steps:
       - checkout
-      - run: apt update && apt -y install git gcc clang cmake libgcrypt20-dev libgtk-3-dev libzip-dev libjansson-dev libpng-dev libzbar-dev libprotobuf-c-dev libsecret-1-dev uuid-dev libprotobuf-dev libqrencode-dev
+      - run: apt update && apt -y install git gcc clang cmake libgcrypt20-dev libgtk-3-dev libzip-dev libjansson-dev libpng-dev libzbar-dev libprotobuf-c-dev libsecret-1-dev uuid-dev libprotobuf-dev libqrencode-dev libayatana-appindicator3-dev
       - run: chmod +x .ci/install_deps.sh && .ci/install_deps.sh
       - run: chmod +x .ci/install_otpclient.sh && .ci/install_otpclient.sh
 
@@ -24,7 +33,7 @@ jobs:
       - image: fedora:latest
     steps:
       - checkout
-      - run: dnf -y update && dnf -y install git gcc clang cmake make libgcrypt-devel gtk3-devel libzip-devel jansson-devel libpng-devel zbar-devel protobuf-c-devel libsecret-devel libuuid-devel protobuf-devel qrencode-devel
+      - run: dnf -y update && dnf -y install git gcc clang cmake make libgcrypt-devel gtk3-devel libzip-devel jansson-devel libpng-devel zbar-devel protobuf-c-devel libsecret-devel libuuid-devel protobuf-devel qrencode-devel libayatana-appindicator-gtk3-devel
       - run: chmod +x .ci/install_deps.sh && .ci/install_deps.sh
       - run: chmod +x .ci/install_otpclient.sh && .ci/install_otpclient.sh
 
@@ -33,7 +42,7 @@ jobs:
       - image: ubuntu:24.04
     steps:
       - checkout
-      - run: apt update && DEBIAN_FRONTEND=noninteractive apt -y install git gcc clang cmake libgcrypt20-dev libgtk-3-dev libzip-dev libjansson-dev libpng-dev libzbar-dev libprotobuf-c-dev libsecret-1-dev uuid-dev libprotobuf-dev libqrencode-dev
+      - run: apt update && DEBIAN_FRONTEND=noninteractive apt -y install git gcc clang cmake libgcrypt20-dev libgtk-3-dev libzip-dev libjansson-dev libpng-dev libzbar-dev libprotobuf-c-dev libsecret-1-dev uuid-dev libprotobuf-dev libqrencode-dev libayatana-appindicator3-dev
       - run: chmod +x .ci/install_deps.sh && .ci/install_deps.sh
       - run: chmod +x .ci/install_otpclient.sh && .ci/install_otpclient.sh
 
@@ -41,6 +50,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - archlinux_notray
       - archlinux
       - debianLatestStable
       - fedoraLatestStable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(IS_FLATPAK "Use flatpak app's config folder to store the database" OFF)
 option(BUILD_GUI "Build the GTK UI" ON)
 option(BUILD_CLI "Build the CLI" ON)
+option(ENABLE_MINIMIZE_TO_TRAY "Enable minimize to tray feature" OFF)
 
 set(CMAKE_C_STANDARD 11)
 set(COMMON_C_FLAGS
@@ -46,8 +47,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${COMMON_LINKER_FLAGS}")
 endif()
 
-add_definitions(-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\")
-
+add_definitions(
+    -DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"
+    -DDESTINATION="${CMAKE_INSTALL_PREFIX}"
+)
+if (ENABLE_MINIMIZE_TO_TRAY)
+  add_definitions(-DENABLE_MINIMIZE_TO_TRAY=1)
+endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-add-needed -Wl,--as-needed -Wl,--no-undefined")
@@ -70,6 +76,9 @@ pkg_check_modules(UUID REQUIRED uuid>=2.34.0)
 pkg_check_modules(PROTOC REQUIRED libprotobuf-c>=1.3.0)
 pkg_check_modules(LIBSECRET REQUIRED libsecret-1>=0.20.0)
 pkg_check_modules(LIBQRENCODE REQUIRED libqrencode>=4.0.2)
+if (ENABLE_MINIMIZE_TO_TRAY)
+  pkg_check_modules(APPINDICATOR REQUIRED ayatana-appindicator3-0.1)
+endif()
 
 set(COMMON_INCDIRS
         ${GCRYPT_INCLUDE_DIRS}
@@ -93,12 +102,18 @@ set(COMMON_LIBS
 
 if(BUILD_GUI)
     add_subdirectory(src/gui)
+    if(ENABLE_MINIMIZE_TO_TRAY)
+        target_include_directories(${PROJECT_NAME} PRIVATE ${APPINDICATOR_INCLUDE_DIRS})
+    endif()
     target_link_libraries(${PROJECT_NAME}
             ${GTK3_LIBRARIES}
             ${PNG_LIBRARIES}
             ${ZBAR_LIBRARIES}
             ${COMMON_LIBS}
     )
+    if(ENABLE_MINIMIZE_TO_TRAY)
+        target_link_libraries(${PROJECT_NAME} ${APPINDICATOR_LIBRARIES})
+    endif()
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "otpclient")
 
     install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/src/gui/app.c
+++ b/src/gui/app.c
@@ -24,6 +24,9 @@
 #include "dbinfo-cb.h"
 #include "change-file-cb.h"
 #include "change-db-sec.h"
+#ifdef ENABLE_MINIMIZE_TO_TRAY
+#include "tray.h"
+#endif
 
 #ifndef IS_FLATPAK
 static gchar     *get_db_path               (AppData            *app_data);
@@ -343,6 +346,7 @@ set_config_data (gint     *width,
         app_data->auto_lock = g_key_file_get_boolean (kf, "config", "auto_lock", NULL);
         app_data->inactivity_timeout = g_key_file_get_integer (kf, "config", "inactivity_timeout", NULL);
         app_data->use_dark_theme = g_key_file_get_boolean (kf, "config", "dark_theme", NULL);
+        app_data->use_tray = g_key_file_get_boolean (kf, "config", "use_tray", NULL);
         // handle migration from disable_secret_service to use_secret_service
         tmp = g_key_file_get_boolean (kf, "config", "disable_secret_service", &err);
         if (tmp == TRUE || (tmp == FALSE && err == NULL)) {
@@ -383,7 +387,6 @@ migrate_secretservice_kf (AppData  *app_data,
     }
 }
 
-
 static void
 create_main_window (gint     width,
                     gint     height,
@@ -396,6 +399,11 @@ create_main_window (gint     width,
 
     GtkWidget *lock_btn = GTK_WIDGET(gtk_builder_get_object (app_data->builder, "lock_btn_id"));
     g_signal_connect (lock_btn, "clicked", G_CALLBACK(lock_app), app_data);
+    #ifdef ENABLE_MINIMIZE_TO_TRAY
+    if (app_data->use_tray) {
+        init_tray_icon(app_data);
+    }
+    #endif
     if (app_data->use_secret_service == TRUE) {
         // secret service is enabled, so we can't lock the app
         gtk_widget_set_sensitive (lock_btn, FALSE);

--- a/src/gui/data.h
+++ b/src/gui/data.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <gtk/gtk.h>
+#ifdef ENABLE_MINIMIZE_TO_TRAY
+#include <libayatana-appindicator/app-indicator.h>
+#endif
 #include <jansson.h>
 #include "../common/db-common.h"
 
@@ -15,6 +18,9 @@ typedef struct app_data_t {
 
     GtkWidget *main_window;
     GtkTreeView *tree_view;
+    #ifdef ENABLE_MINIMIZE_TO_TRAY
+    AppIndicator *indicator;
+    #endif
 
     GtkClipboard *clipboard;
 
@@ -44,6 +50,8 @@ typedef struct app_data_t {
     gboolean is_reorder_active;
 
     gboolean use_secret_service;
+
+    gboolean use_tray;
 
     GDateTime *last_user_activity;
 

--- a/src/gui/tray.c
+++ b/src/gui/tray.c
@@ -1,0 +1,60 @@
+#ifdef ENABLE_MINIMIZE_TO_TRAY
+#include <gtk/gtk.h>
+#include <glib.h>
+#include <libayatana-appindicator/app-indicator.h>
+#include "data.h"
+
+gboolean hide_to_tray(GtkWidget *widget, GdkEvent *event __attribute__((unused)), gpointer user_data) {
+    AppData *app_data = (AppData*) user_data;
+    if (app_data->use_tray) {
+        gtk_widget_hide(widget);
+        return TRUE; // Prevent the app shutdown, so it just minimizes
+    }
+    return FALSE;
+}
+
+void quit_app(GtkWidget *widget __attribute__((unused)), gpointer user_data __attribute__((unused))) {
+    GApplication *app = g_application_get_default();
+    g_application_quit(G_APPLICATION(app));
+}
+
+void show_main_window(GtkMenuItem *item __attribute__((unused)), gpointer user_data) {
+    AppData *app_data = (AppData*) user_data;
+    gtk_widget_show_all(GTK_WIDGET(app_data->main_window));
+    gtk_window_present(GTK_WINDOW(app_data->main_window));
+}
+
+void init_tray_icon(AppData *app_data) {
+    gchar *icon_path = g_build_filename(DESTINATION, "share/icons/hicolor/scalable/apps/com.github.paolostivanin.OTPClient.svg", NULL);
+    app_data->indicator = app_indicator_new("otpclient", icon_path, APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+    g_free (icon_path);
+    app_indicator_set_status(app_data->indicator, APP_INDICATOR_STATUS_ACTIVE);
+
+    // Create a menu for the system tray icon
+    GtkWidget *menu = gtk_menu_new();
+    GtkWidget *show_item = gtk_menu_item_new_with_label("Show OTPClient");
+    g_signal_connect(show_item, "activate", G_CALLBACK(show_main_window), app_data);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), show_item);
+
+    GtkWidget *quit_item = gtk_menu_item_new_with_label("Quit");
+    g_signal_connect(quit_item, "activate", G_CALLBACK(quit_app), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), quit_item);
+
+    gtk_widget_show_all(menu);
+    app_indicator_set_menu( app_data->indicator, GTK_MENU(menu));
+
+    g_signal_connect(app_data->main_window, "delete-event", G_CALLBACK(hide_to_tray), app_data);
+}
+
+void switch_tray_use(AppData *app_data) {
+    if (app_data->use_tray) {
+        if (app_data->indicator == NULL) {
+            init_tray_icon(app_data);    
+        } else {
+            app_indicator_set_status(app_data->indicator, APP_INDICATOR_STATUS_ACTIVE);
+        }
+    } else {
+        app_indicator_set_status(app_data->indicator, APP_INDICATOR_STATUS_PASSIVE);
+    }
+}
+#endif

--- a/src/gui/tray.h
+++ b/src/gui/tray.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include "data.h"
+
+G_BEGIN_DECLS
+
+void init_tray_icon            (AppData *app_data);
+void switch_tray_use           (AppData *app_data);
+
+G_END_DECLS

--- a/src/gui/ui/otpclient.ui
+++ b/src/gui/ui/otpclient.ui
@@ -1991,7 +1991,7 @@ but not the number of digits and/or the period/counter.</property>
         </child>
         <child>
           <!-- n-columns=3 n-rows=7 -->
-          <object class="GtkGrid">
+          <object class="GtkGrid" id="grid_settings">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
@@ -2168,6 +2168,29 @@ but not the number of digits and/or the period/counter.</property>
               <packing>
                 <property name="left-attach">1</property>
                 <property name="top-attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Enable minimize to tray</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="tray_switch_id">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">7</property>
               </packing>
             </child>
             <child>


### PR DESCRIPTION
Hello,

First, thank you very much for this wonderful program. 
It is very nice to be able to use a secure device for security purposes.

Some sites are very annoying with MFA, and require multiple entries. 
I tend to prefer having it minimized to tray for these cases. 
In terms of security, I think it does not really pose a problem since there are good auto lock on system lock and inactive settings that are available already.

Although I think if it were to be accepted, it would make sense to add a setting for it and disable it by default.

Let me know what you think!