### PR TITLE
gui: add interactive search/filter to OTP list (Ctrl+F)

### DIFF
--- a/src/gui/data.h
+++ b/src/gui/data.h
@@ -18,6 +18,9 @@ typedef struct app_data_t {
 
     GtkWidget *main_window;
     GtkTreeView *tree_view;
+    GtkListStore *list_store;
+    GtkTreeModelFilter *filter_model;
+    GtkWidget *search_entry;
     #ifdef ENABLE_MINIMIZE_TO_TRAY
     AppIndicator *indicator;
     #endif

--- a/src/gui/edit-row-cb.c
+++ b/src/gui/edit-row-cb.c
@@ -44,12 +44,8 @@ edit_row_cb (GtkMenuItem *menu_item UNUSED,
     CAST_USER_DATA(AppData, app_data, user_data);
     edit_data->db_data = app_data->db_data;
 
-    GtkTreeModel *model = gtk_tree_view_get_model (app_data->tree_view);
-
-    edit_data->list_store = GTK_LIST_STORE(model);
-
-    if (gtk_tree_selection_get_selected (gtk_tree_view_get_selection (app_data->tree_view), &model, &edit_data->iter)) {
-        gtk_tree_model_get (model, &edit_data->iter, COLUMN_ACC_LABEL, &edit_data->current_label, COLUMN_ACC_ISSUER, &edit_data->current_issuer, -1);
+    if (get_selected_liststore_iter (app_data, &edit_data->list_store, &edit_data->iter)) {
+        gtk_tree_model_get (GTK_TREE_MODEL(edit_data->list_store), &edit_data->iter, COLUMN_ACC_LABEL, &edit_data->current_label, COLUMN_ACC_ISSUER, &edit_data->current_issuer, -1);
         show_edit_dialog (edit_data, app_data);
         g_free (edit_data->current_label);
         g_free (edit_data->current_issuer);

--- a/src/gui/gui-misc.c
+++ b/src/gui/gui-misc.c
@@ -304,3 +304,29 @@ load_new_db (AppData  *app_data,
     g_slist_free_full (app_data->db_data->data_to_add, json_free);
     app_data->db_data->data_to_add = NULL;
 }
+
+
+gboolean
+get_selected_liststore_iter (AppData       *app_data,
+                             GtkListStore **list_store,
+                             GtkTreeIter   *iter)
+{
+    GtkTreeModel *model = gtk_tree_view_get_model (app_data->tree_view);
+    GtkTreeIter view_iter;
+    if (!gtk_tree_selection_get_selected (gtk_tree_view_get_selection (app_data->tree_view), &model, &view_iter)) {
+        return FALSE;
+    }
+
+    if (GTK_IS_TREE_MODEL_FILTER (model)) {
+        GtkTreeIter child_iter;
+        GtkTreeModel *child_model = gtk_tree_model_filter_get_model (GTK_TREE_MODEL_FILTER(model));
+        gtk_tree_model_filter_convert_iter_to_child_iter (GTK_TREE_MODEL_FILTER(model), &child_iter, &view_iter);
+        *list_store = GTK_LIST_STORE(child_model);
+        *iter = child_iter;
+        return TRUE;
+    }
+
+    *list_store = GTK_LIST_STORE(model);
+    *iter = view_iter;
+    return TRUE;
+}

--- a/src/gui/gui-misc.h
+++ b/src/gui/gui-misc.h
@@ -14,6 +14,10 @@ void      icon_press_cb                (GtkEntry       *entry,
 guint     get_row_number_from_iter     (GtkListStore   *list_store,
                                         GtkTreeIter     iter);
 
+gboolean  get_selected_liststore_iter  (AppData        *app_data,
+                                        GtkListStore  **list_store,
+                                        GtkTreeIter    *iter);
+
 void      send_ok_cb                   (GtkWidget      *entry,
                                         gpointer        user_data);
 

--- a/src/gui/liststore-misc.c
+++ b/src/gui/liststore-misc.c
@@ -33,7 +33,9 @@ gboolean
 traverse_liststore (gpointer user_data)
 {
     CAST_USER_DATA(AppData, app_data, user_data);
-    gtk_tree_model_foreach (GTK_TREE_MODEL(gtk_tree_view_get_model (app_data->tree_view)), foreach_func_update_otps, app_data);
+    if (app_data->list_store != NULL) {
+        gtk_tree_model_foreach (GTK_TREE_MODEL(app_data->list_store), foreach_func_update_otps, app_data);
+    }
 
     return TRUE;
 }

--- a/src/gui/settings-cb.c
+++ b/src/gui/settings-cb.c
@@ -149,6 +149,9 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
                 g_printerr ("%s\n", _("Error while saving the config file."));
             }
             gtk_tree_view_set_search_column (GTK_TREE_VIEW(app_data->tree_view), app_data->search_column + 1);
+            if (app_data->filter_model != NULL) {
+                gtk_tree_model_filter_refilter (app_data->filter_model);
+            }
             break;
         case GTK_RESPONSE_CANCEL:
             break;

--- a/src/gui/show-qr-cb.c
+++ b/src/gui/show-qr-cb.c
@@ -25,11 +25,10 @@ show_qr_cb (GtkMenuItem *menu_item UNUSED,
 {
     CAST_USER_DATA(AppData, app_data, user_data);
 
-    GtkTreeModel *model = gtk_tree_view_get_model (app_data->tree_view);
-    GtkListStore *list_store = GTK_LIST_STORE(model);
+    GtkListStore *list_store = NULL;
     GtkTreeIter iter;
 
-    if (gtk_tree_selection_get_selected (gtk_tree_view_get_selection (app_data->tree_view), &model, &iter) == FALSE) {
+    if (!get_selected_liststore_iter (app_data, &list_store, &iter)) {
         show_message_dialog (app_data->main_window, "Error: a row must be selected in order to get the QR Code.", GTK_MESSAGE_ERROR);
         return;
     }

--- a/src/gui/ui/otpclient.ui
+++ b/src/gui/ui/otpclient.ui
@@ -1237,6 +1237,19 @@ but not the number of digits and/or the period/counter.</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
+          <object class="GtkSearchEntry" id="search_entry_id">
+            <property name="visible">False</property>
+            <property name="can-focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="placeholder-text" translatable="yes">Search</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkScrolledWindow" id="scrolledwin_id">
             <property name="visible">True</property>
             <property name="can-focus">True</property>


### PR DESCRIPTION
Introduce a GtkSearchEntry with live filtering backed by GtkTreeModelFilter. The search can be toggled via Ctrl+F, auto-focuses when shown, clears on hide, and preserves correct row activation and selection behavior.

Internally, refactor tree model handling to consistently operate on the underlying GtkListStore:
- Track list_store and filter_model in AppData
- Add helpers to safely map filtered iters/paths to the real list store
- Fix edit/delete/QR/show/reorder logic when filtering is active
- Ensure sort order is saved from the base model
- Refilter model on settings changes

Also improves lifecycle handling and cleanup of models.