### PR TITLE
gui: simplify search by removing column selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(OTPClient VERSION "4.1.2" LANGUAGES "C")
+project(OTPClient VERSION "4.2.0" LANGUAGES "C")
 include(GNUInstallDirs)
 
 configure_file("src/common/version.h.in" "version.h")

--- a/src/gui/app.c
+++ b/src/gui/app.c
@@ -107,7 +107,6 @@ activate (GtkApplication    *app,
     gint width = 0, height = 0;
     app_data->show_next_otp = FALSE; // next otp not shown by default
     app_data->disable_notifications = FALSE; // notifications enabled by default
-    app_data->search_column = 0; // account
     app_data->auto_lock = FALSE; // disabled by default
     app_data->inactivity_timeout = 0; // never
     app_data->use_dark_theme = FALSE; // light theme by default
@@ -373,7 +372,6 @@ set_config_data (gint     *width,
         *height = g_key_file_get_integer (kf, "config", "window_height", NULL);
         app_data->show_next_otp = g_key_file_get_boolean (kf, "config", "show_next_otp", NULL);
         app_data->disable_notifications = g_key_file_get_boolean (kf, "config", "notifications", NULL);
-        app_data->search_column = g_key_file_get_integer (kf, "config", "search_column", NULL);
         app_data->auto_lock = g_key_file_get_boolean (kf, "config", "auto_lock", NULL);
         app_data->inactivity_timeout = g_key_file_get_integer (kf, "config", "inactivity_timeout", NULL);
         app_data->use_dark_theme = g_key_file_get_boolean (kf, "config", "dark_theme", NULL);

--- a/src/gui/data.h
+++ b/src/gui/data.h
@@ -29,7 +29,6 @@ typedef struct app_data_t {
 
     gboolean show_next_otp;
     gboolean disable_notifications;
-    gint search_column;
     gboolean auto_lock;
     gint inactivity_timeout;
 

--- a/src/gui/settings-cb.c
+++ b/src/gui/settings-cb.c
@@ -71,7 +71,6 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
     // Therefore, having these values as default is exactly what we want. So no need to check whether the key is missing.
     app_data->show_next_otp = g_key_file_get_boolean (kf, "config", "show_next_otp", NULL);
     app_data->disable_notifications = g_key_file_get_boolean (kf, "config", "notifications", NULL);
-    app_data->search_column = g_key_file_get_integer (kf, "config", "search_column", NULL);
     app_data->auto_lock = g_key_file_get_boolean (kf, "config", "auto_lock", NULL);
     app_data->inactivity_timeout = g_key_file_get_integer (kf, "config", "inactivity_timeout", NULL);
     app_data->use_dark_theme = g_key_file_get_boolean (kf, "config", "dark_theme", NULL);
@@ -87,7 +86,6 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
     GtkWidget *dialog = GTK_WIDGET(gtk_builder_get_object (builder, "settings_diag_id"));
     GtkWidget *sno_switch = GTK_WIDGET(gtk_builder_get_object (builder, "nextotp_switch_id"));
     GtkWidget *dn_switch = GTK_WIDGET(gtk_builder_get_object (builder, "notif_switch_id"));
-    GtkWidget *sc_cb = GTK_WIDGET(gtk_builder_get_object (builder, "search_by_cb_id"));
     settings_data->al_switch = GTK_WIDGET(gtk_builder_get_object (builder, "autolock_switch_id"));
     g_signal_connect (settings_data->al_switch, "state-set", G_CALLBACK(handle_secretservice_switch), settings_data);
     settings_data->inactivity_cb = GTK_WIDGET(gtk_builder_get_object (builder, "autolock_inactive_cb_id"));
@@ -111,10 +109,7 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
     gtk_switch_set_active (GTK_SWITCH(dt_switch), app_data->use_dark_theme);
     gtk_switch_set_active (GTK_SWITCH(settings_data->dss_switch), app_data->use_secret_service);
     gtk_switch_set_active (GTK_SWITCH(settings_data->tray_switch), app_data->use_tray);
-    gchar *active_id_string = g_strdup_printf ("%d", app_data->search_column);
-    gtk_combo_box_set_active_id (GTK_COMBO_BOX(sc_cb), active_id_string);
-    g_free (active_id_string);
-    active_id_string = g_strdup_printf ("%d", app_data->inactivity_timeout);
+    gchar *active_id_string = g_strdup_printf ("%d", app_data->inactivity_timeout);
     gtk_combo_box_set_active_id (GTK_COMBO_BOX(settings_data->inactivity_cb), active_id_string);
     g_free (active_id_string);
 
@@ -127,7 +122,6 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
         case GTK_RESPONSE_OK:
             app_data->show_next_otp = gtk_switch_get_active (GTK_SWITCH(sno_switch));
             app_data->disable_notifications = gtk_switch_get_active (GTK_SWITCH(dn_switch));
-            app_data->search_column = (gint)g_ascii_strtoll (gtk_combo_box_get_active_id (GTK_COMBO_BOX(sc_cb)), NULL, 10);
             app_data->auto_lock = gtk_switch_get_active (GTK_SWITCH(settings_data->al_switch));
             app_data->inactivity_timeout = (gint)g_ascii_strtoll (gtk_combo_box_get_active_id (GTK_COMBO_BOX(settings_data->inactivity_cb)), NULL, 10);
             app_data->use_dark_theme = gtk_switch_get_active (GTK_SWITCH(dt_switch));
@@ -135,7 +129,6 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
             app_data->use_tray = gtk_switch_get_active (GTK_SWITCH(settings_data->tray_switch));
             g_key_file_set_boolean (kf, "config", "show_next_otp", app_data->show_next_otp);
             g_key_file_set_boolean (kf, "config", "notifications", app_data->disable_notifications);
-            g_key_file_set_integer (kf, "config", "search_column", app_data->search_column);
             g_key_file_set_boolean (kf, "config", "auto_lock", app_data->auto_lock);
             g_key_file_set_integer (kf, "config", "inactivity_timeout", app_data->inactivity_timeout);
             g_key_file_set_boolean (kf, "config", "dark_theme", app_data->use_dark_theme);
@@ -148,7 +141,6 @@ settings_dialog_cb (GSimpleAction *simple UNUSED,
             if (!g_key_file_save_to_file (kf, cfg_file_path, NULL)) {
                 g_printerr ("%s\n", _("Error while saving the config file."));
             }
-            gtk_tree_view_set_search_column (GTK_TREE_VIEW(app_data->tree_view), app_data->search_column + 1);
             if (app_data->filter_model != NULL) {
                 gtk_tree_model_filter_refilter (app_data->filter_model);
             }

--- a/src/gui/ui/otpclient.ui
+++ b/src/gui/ui/otpclient.ui
@@ -2033,17 +2033,6 @@ but not the number of digits and/or the period/counter.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Search by</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkSwitch" id="notif_switch_id">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
@@ -2053,22 +2042,6 @@ but not the number of digits and/or the period/counter.</property>
               <packing>
                 <property name="left-attach">1</property>
                 <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="search_by_cb_id">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="active">0</property>
-                <property name="active-id">0</property>
-                <items>
-                  <item id="0" translatable="yes">Account</item>
-                  <item id="1" translatable="yes">Issuer</item>
-                </items>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>


### PR DESCRIPTION
  Drop the configurable "search by" option and related settings/state.
  Search now matches query against type, account label, and issuer uniformly.
  Clean up settings UI, config handling, and treeview search logic accordingly.