### PR TITLE
feat: add cross-desktop search provider for GNOME and KDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(OTPClient VERSION "4.3.1" LANGUAGES "C")
+project(OTPClient VERSION "4.4.0" LANGUAGES "C")
 include(GNUInstallDirs)
 
 configure_file("src/common/version.h.in" "version.h")
@@ -12,10 +12,11 @@ set(CMAKE_C_EXTENSIONS OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-option(IS_FLATPAK "Use flatpak app's config folder to store the database" OFF)
 option(BUILD_GUI "Build the GTK UI" ON)
 option(BUILD_CLI "Build the CLI" ON)
+option(BUILD_SEARCH_PROVIDER "Build the search provider integration (GNOME Shell / KDE KRunner)" ON)
 option(ENABLE_MINIMIZE_TO_TRAY "Enable minimize to tray feature" OFF)
+option(IS_FLATPAK "Use flatpak app's config folder to store the database" OFF)
 
 set(COMMON_C_OPTIONS
         -Wall -Wextra -O3 -Wformat=2 -Wmissing-format-attribute -fstack-protector-strong
@@ -138,6 +139,25 @@ if(BUILD_CLI)
 
     install(TARGETS ${PROJECT_NAME}-cli DESTINATION bin)
     install(FILES man/otpclient-cli.1 DESTINATION share/man/man1)
+endif()
+
+if(BUILD_SEARCH_PROVIDER)
+    add_subdirectory(src/search-provider)
+    otpclient_apply_target_settings(${PROJECT_NAME}-search-provider)
+    target_link_libraries(${PROJECT_NAME}-search-provider
+            PkgConfig::GTK3
+            ${COMMON_LIBS}
+    )
+    install(TARGETS ${PROJECT_NAME}-search-provider DESTINATION bin)
+    # GNOME Search Provider metadata
+    install(FILES data/gnome-shell/search-providers/com.github.paolostivanin.OTPClient.SearchProvider.ini DESTINATION share/gnome-shell/search-providers)
+
+    # D-Bus Service activation files (allows KRunner/GNOME to launch the binary on demand)
+    install(FILES data/dbus-1/services/com.github.paolostivanin.OTPClient.SearchProvider.service DESTINATION share/dbus-1/services)
+    install(FILES data/dbus-1/services/com.github.paolostivanin.OTPClient.KRunner.service DESTINATION share/dbus-1/services)
+
+    # KDE Plasma 6 KRunner Metadata
+    install(FILES data/krunner/com.github.paolostivanin.OTPClient.KRunner.desktop DESTINATION share/krunner/dbusplugins)
 endif()
 
 install(FILES data/com.github.paolostivanin.OTPClient.appdata.xml DESTINATION share/metainfo)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See this [wiki section](https://github.com/paolostivanin/OTPClient/wiki/Secure-M
 - local database is encrypted using AES256-GCM
   - key is derived using Argon2id with the following default parameters: 4 iterations, 128 MiB memory cost, 4 parallelism, 32 taglen. The first three parameters can be changed by the user.
   - decrypted file is never saved (and hopefully never swapped) to disk. While the app is running, the decrypted content resides in a "secure memory" buffer allocated by Gcrypt
+- GNOME Shell search provider and KDE KRunner integration (requires secret service-enabled key storage)
 
 ## Testing
 * Before each release, I run PVS Studio and Coverity in order to catch even more bugs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,9 @@ The following list describes whether a version is eligible or not for security u
 
 | Version | Supported          | EOL         |
 |---------|--------------------|-------------|
-| 4.3.x   | :white_check_mark: Yes | -           |
-| 4.2.x   | :white_check_mark: Yes | 27-Feb-2026 |
+| 4.4.x   | :white_check_mark: Yes | -           |
+| 4.3.x   | :white_check_mark: Yes | 27-Feb-2026 |
+| 4.2.x   | :white_check_mark: Yes | 20-Feb-2026 |
 | 4.1.x   | :white_check_mark: Yes | 06-Feb-2026 |
 | 4.0.x   | :x: No                 | 30-Jun-2025 |
 

--- a/data/dbus-1/services/com.github.paolostivanin.OTPClient.KRunner.service
+++ b/data/dbus-1/services/com.github.paolostivanin.OTPClient.KRunner.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.github.paolostivanin.OTPClient.KRunner
+Exec=otpclient-search-provider --kde

--- a/data/dbus-1/services/com.github.paolostivanin.OTPClient.SearchProvider.service
+++ b/data/dbus-1/services/com.github.paolostivanin.OTPClient.SearchProvider.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.github.paolostivanin.OTPClient.SearchProvider
+Exec=otpclient-search-provider --gnome

--- a/data/gnome-shell/search-providers/com.github.paolostivanin.OTPClient.SearchProvider.ini
+++ b/data/gnome-shell/search-providers/com.github.paolostivanin.OTPClient.SearchProvider.ini
@@ -1,0 +1,5 @@
+[Shell Search Provider]
+DesktopId=com.github.paolostivanin.OTPClient.desktop
+BusName=com.github.paolostivanin.OTPClient.SearchProvider
+ObjectPath=/com/github/paolostivanin/OTPClient/SearchProvider
+Version=2

--- a/data/krunner/com.github.paolostivanin.OTPClient.KRunner.desktop
+++ b/data/krunner/com.github.paolostivanin.OTPClient.KRunner.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=OTPClient
+Comment=Search OTP entries
+Type=Service
+Icon=com.github.paolostivanin.OTPClient
+# These must be exactly your D-Bus identifiers
+X-KDE-ServiceTypes=Plasma/Runner
+X-Plasma-API=DBus
+X-Plasma-DBusRunner-Service=com.github.paolostivanin.OTPClient.KRunner
+X-Plasma-DBusRunner-Path=/com/github/paolostivanin/OTPClient/KRunner
+# This MUST match the filename (minus .desktop)
+X-KDE-PluginInfo-Name=com.github.paolostivanin.OTPClient.KRunner
+X-KDE-PluginInfo-EnabledByDefault=true

--- a/src/gui/data.h
+++ b/src/gui/data.h
@@ -61,6 +61,8 @@ typedef struct app_data_t {
 
     GDateTime *last_user_activity;
 
+    gboolean search_provider_enabled;
+
     GtkWidget *diag_rcdb;
     GtkFileChooserAction open_db_file_action;
 

--- a/src/gui/otpclient-application.c
+++ b/src/gui/otpclient-application.c
@@ -350,6 +350,11 @@ set_config_data (gint    *width,
         app_data->use_dark_theme = g_key_file_get_boolean (kf, "config", "dark_theme", NULL);
         app_data->use_tray = g_key_file_get_boolean (kf, "config", "use_tray", NULL);
         app_data->use_secret_service = g_key_file_get_boolean (kf, "config", "use_secret_service", NULL);
+        if (g_key_file_has_key (kf, "config", "search_provider_enabled", NULL)) {
+            app_data->search_provider_enabled = g_key_file_get_boolean (kf, "config", "search_provider_enabled", NULL);
+        } else {
+            app_data->search_provider_enabled = TRUE;
+        }
         load_validity_colors (kf, app_data);
         g_object_set (gtk_settings_get_default (), "gtk-application-prefer-dark-theme", app_data->use_dark_theme, NULL);
         g_key_file_free (kf);
@@ -447,6 +452,7 @@ init_app_defaults (AppData *app_data)
     app_data->use_secret_service = TRUE; // secret service enabled by default
     app_data->is_reorder_active = FALSE; // when app is started, reorder is not set
     app_data->use_tray = FALSE; // do not use tray by default
+    app_data->search_provider_enabled = TRUE; // search provider enabled by default
     // open_db_file_action is set only on first startup and not when the db is deleted but the cfg file is there, therefore we need a default action
     app_data->open_db_file_action = GTK_FILE_CHOOSER_ACTION_SAVE;
     app_data->window_width = 0;

--- a/src/gui/ui/otpclient.ui
+++ b/src/gui/ui/otpclient.ui
@@ -2160,7 +2160,7 @@ but not the number of digits and/or the period/counter.</property>
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=10 -->
+          <!-- n-columns=3 n-rows=11 -->
           <object class="GtkGrid" id="grid_settings">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -2405,6 +2405,29 @@ but not the number of digits and/or the period/counter.</property>
               <packing>
                 <property name="left-attach">1</property>
                 <property name="top-attach">9</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Enable search provider</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">10</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="search_provider_switch_id">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">10</property>
               </packing>
             </child>
             <child>

--- a/src/search-provider/CMakeLists.txt
+++ b/src/search-provider/CMakeLists.txt
@@ -1,0 +1,12 @@
+file(GLOB SEARCH_PROVIDER_HEADER_FILES
+        *.h
+        ../common/*.h
+)
+
+file(GLOB SEARCH_PROVIDER_SOURCE_FILES
+        *.c
+        ../common/*.c
+)
+
+add_executable(${PROJECT_NAME}-search-provider ${SEARCH_PROVIDER_SOURCE_FILES} ${SEARCH_PROVIDER_HEADER_FILES})
+set_target_properties(${PROJECT_NAME}-search-provider PROPERTIES OUTPUT_NAME "otpclient-search-provider")

--- a/src/search-provider/search-provider.c
+++ b/src/search-provider/search-provider.c
@@ -1,0 +1,364 @@
+#include <gio/gio.h>
+#include <glib.h>
+#include <jansson.h>
+#include <libsecret/secret.h>
+#include <gcrypt.h>
+#include <cotp.h>
+#include <time.h>
+
+/* Project-specific headers */
+#include "../common/common.h"
+#include "../common/db-common.h"
+#include "../common/file-size.h"
+#include "../common/secret-schema.h"
+
+#define KRUNNER_BUS "com.github.paolostivanin.OTPClient.KRunner"
+#define KRUNNER_PATH "/com/github/paolostivanin/OTPClient/KRunner"
+#define GNOME_BUS "com.github.paolostivanin.OTPClient.SearchProvider"
+#define GNOME_PATH "/com/github/paolostivanin/OTPClient/SearchProvider"
+
+typedef struct otp_search_entry_t {
+    gchar *id;
+    gchar *label;
+    gchar *issuer;
+    gchar *otp_value;
+} OtpSearchEntry;
+
+/* Forward Declarations */
+static void otp_search_entry_free (OtpSearchEntry *entry);
+static GPtrArray *load_entries (void);
+static gboolean entry_matches_terms (const OtpSearchEntry *entry, gchar **terms, gsize terms_len);
+static gchar *get_entry_otp_value (json_t *obj);
+static gchar *get_otp_for_id (const gchar *id);
+static void send_notification (const gchar *label, const gchar *otp_value);
+static gchar *get_db_path (void);
+static gboolean get_use_secret_service (void);
+static gboolean get_search_provider_enabled (void);
+
+/* --- Introspection XML --- */
+static const gchar *krunner_introspection_xml =
+"<node>"
+"  <interface name='org.kde.krunner1'>"
+"    <method name='Match'><arg type='s' name='query' direction='in'/><arg type='a(sssida{sv})' name='matches' direction='out'/></method>"
+"    <method name='Run'><arg type='s' name='id' direction='in'/><arg type='s' name='actionId' direction='in'/></method>"
+"    <method name='Actions'><arg type='a(sss)' name='actions' direction='out'/></method>"
+"  </interface>"
+"</node>";
+
+static const gchar *gnome_introspection_xml =
+"<node>"
+"  <interface name='org.gnome.Shell.SearchProvider2'>"
+"    <method name='GetInitialResultSet'><arg type='as' name='terms' direction='in'/><arg type='as' name='results' direction='out'/></method>"
+"    <method name='GetSubsearchResultSet'><arg type='as' name='prev' direction='in'/><arg type='as' name='terms' direction='in'/><arg type='as' name='results' direction='out'/></method>"
+"    <method name='GetResultMetas'><arg type='as' name='results' direction='in'/><arg type='aa{sv}' name='metas' direction='out'/></method>"
+"    <method name='ActivateResult'><arg type='s' name='id' direction='in'/><arg type='as' name='terms' direction='in'/><arg type='u' name='t' direction='in'/></method>"
+"    <method name='LaunchSearch'><arg type='as' name='terms' direction='in'/><arg type='u' name='t' direction='in'/></method>"
+"  </interface>"
+"</node>";
+
+/* --- Helpers Implementation --- */
+
+static gchar *get_db_path (void) {
+    gchar *db_path = NULL;
+    gchar *cfg_file_path = NULL;
+    GKeyFile *kf = g_key_file_new ();
+#ifdef IS_FLATPAK
+    cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
+#else
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
+#endif
+    if (g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
+        if (g_key_file_load_from_file (kf, cfg_file_path, G_KEY_FILE_NONE, NULL)) {
+            db_path = g_key_file_get_string (kf, "config", "db_path", NULL);
+        }
+    }
+    g_key_file_free (kf);
+    g_free (cfg_file_path);
+    return db_path;
+}
+
+static gboolean get_use_secret_service (void) {
+    gboolean use_secret_service = TRUE;
+    GKeyFile *kf = g_key_file_new ();
+    gchar *cfg_file_path = NULL;
+#ifdef IS_FLATPAK
+    cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
+#else
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
+#endif
+    if (g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
+        if (g_key_file_load_from_file (kf, cfg_file_path, G_KEY_FILE_NONE, NULL)) {
+            use_secret_service = g_key_file_get_boolean (kf, "config", "use_secret_service", NULL);
+        }
+    }
+    g_key_file_free (kf);
+    g_free (cfg_file_path);
+    return use_secret_service;
+}
+
+static gboolean get_search_provider_enabled (void) {
+    gboolean enabled = TRUE;
+    gchar *cfg_file_path = NULL;
+    GKeyFile *kf = g_key_file_new ();
+#ifdef IS_FLATPAK
+    cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
+#else
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
+#endif
+    if (g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
+        if (g_key_file_load_from_file (kf, cfg_file_path, G_KEY_FILE_NONE, NULL)) {
+            GError *err = NULL;
+            enabled = g_key_file_get_boolean (kf, "config", "search_provider_enabled", &err);
+            if (err) { enabled = TRUE; g_error_free(err); }
+        }
+    }
+    g_key_file_free (kf);
+    g_free (cfg_file_path);
+    return enabled;
+}
+
+static void otp_search_entry_free (OtpSearchEntry *entry) {
+    if (!entry) return;
+    g_free (entry->id); g_free (entry->label); g_free (entry->issuer); g_free (entry->otp_value);
+    g_free (entry);
+}
+
+static gchar *get_entry_otp_value (json_t *obj) {
+    const gchar *secret = json_string_value (json_object_get (obj, "secret"));
+    const gchar *type = json_string_value (json_object_get (obj, "type"));
+    if (!secret || !type) return NULL;
+    cotp_error_t cotp_err;
+    const gchar *issuer = json_string_value (json_object_get (obj, "issuer"));
+    gint digits = (gint)json_integer_value (json_object_get (obj, "digits"));
+    gint algo = get_algo_int_from_str (json_string_value (json_object_get (obj, "algo")));
+    gchar *token = NULL;
+    if (g_ascii_strcasecmp (type, "TOTP") == 0) {
+        gint period = (gint)json_integer_value (json_object_get (obj, "period"));
+        glong current_ts = time (NULL);
+        if (issuer != NULL && g_ascii_strcasecmp (issuer, "steam") == 0) {
+            token = get_steam_totp_at (secret, current_ts, period, &cotp_err);
+        } else {
+            token = get_totp_at (secret, current_ts, digits, period, algo, &cotp_err);
+        }
+    } else if (g_ascii_strcasecmp (type, "HOTP") == 0) {
+        gint64 counter = json_integer_value (json_object_get (obj, "counter"));
+        token = get_hotp (secret, counter, digits, algo, &cotp_err);
+    }
+    return token ? g_strdup (token) : NULL;
+}
+
+static GPtrArray *load_entries (void) {
+    GPtrArray *entries = g_ptr_array_new_with_free_func ((GDestroyNotify)otp_search_entry_free);
+    gchar *db_path = get_db_path ();
+    if (!db_path) return entries;
+    DatabaseData *db_data = g_new0 (DatabaseData, 1);
+    db_data->db_path = db_path;
+    if (set_memlock_value (&db_data->max_file_size_from_memlock) == MEMLOCK_ERR) {
+        g_free (db_data->db_path); g_free (db_data); return entries;
+    }
+    if (get_use_secret_service ()) {
+        gchar *pwd = secret_password_lookup_sync (OTPCLIENT_SCHEMA, NULL, NULL, "string", "main_pwd", NULL);
+        if (!pwd) { g_free (db_data->db_path); g_free (db_data); return entries; }
+        db_data->key = secure_strdup (pwd);
+        secret_password_free (pwd);
+    } else { g_free (db_data->db_path); g_free (db_data); return entries; }
+    GError *err = NULL;
+    load_db (db_data, &err);
+    if (err || !db_data->in_memory_json_data) {
+        if (err) {
+            g_clear_error (&err);
+        }
+        gcry_free (db_data->key);
+        g_free (db_data->db_path);
+        g_free (db_data);
+        return entries;
+    }
+    gsize index; json_t *obj;
+    json_array_foreach (db_data->in_memory_json_data, index, obj) {
+        const gchar *label = json_string_value (json_object_get (obj, "label"));
+        if (!label) continue;
+        OtpSearchEntry *entry = g_new0 (OtpSearchEntry, 1);
+        entry->id = g_strdup_printf ("%" G_GUINT32_FORMAT, json_object_get_hash (obj));
+        entry->label = g_strdup (label);
+        const gchar *issuer = json_string_value (json_object_get (obj, "issuer"));
+        entry->issuer = g_strdup (issuer ? issuer : "");
+        entry->otp_value = get_entry_otp_value (obj);
+        g_ptr_array_add (entries, entry);
+    }
+    gcry_free (db_data->key); json_decref (db_data->in_memory_json_data); g_free (db_data->db_path); g_free (db_data);
+    return entries;
+}
+
+static gchar *get_otp_for_id (const gchar *id) {
+    if (!id || !*id) return NULL;
+    GPtrArray *entries = load_entries();
+    gchar *otp = NULL;
+    for (guint i = 0; i < entries->len; i++) {
+        OtpSearchEntry *e = g_ptr_array_index(entries, i);
+        if (g_strcmp0(e->id, id) == 0) {
+            otp = g_strdup(e->otp_value);
+            break;
+        }
+    }
+    g_ptr_array_free(entries, TRUE);
+    return otp;
+}
+
+static gboolean entry_matches_terms (const OtpSearchEntry *entry, gchar **terms, gsize terms_len) {
+    if (terms_len == 0 || !entry->label) return FALSE;
+    g_autofree gchar *l_fold = g_utf8_casefold (entry->label, -1);
+    g_autofree gchar *i_fold = g_utf8_casefold (entry->issuer ? entry->issuer : "", -1);
+    for (gsize i = 0; i < terms_len; i++) {
+        if (!terms[i]) continue;
+        g_autofree gchar *t_fold = g_utf8_casefold (terms[i], -1);
+        if (!g_strstr_len (l_fold, -1, t_fold) && !g_strstr_len (i_fold, -1, t_fold)) return FALSE;
+    }
+    return TRUE;
+}
+
+static void send_notification (const gchar *label, const gchar *otp_value) {
+    if (!otp_value) return;
+    GDBusConnection *conn = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);
+    if (!conn) return;
+    g_autofree gchar *body = g_strdup_printf ("Your code for %s is: %s", label ? label : "Account", otp_value);
+    g_dbus_connection_call (conn, "org.freedesktop.Notifications", "/org/freedesktop/Notifications", "org.freedesktop.Notifications", "Notify",
+                            g_variant_new ("(susssasa{sv}i)", "OTPClient", 0, "com.github.paolostivanin.OTPClient", "OTP Token", body, NULL, NULL, 5000),
+                            NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
+    g_object_unref (conn);
+}
+
+/* --- Handlers --- */
+
+static void handle_gnome_call (GDBusConnection *conn, const gchar *sender, const gchar *path, const gchar *iface,
+                               const gchar *method, GVariant *params, GDBusMethodInvocation *inv, gpointer data) {
+    (void)conn; (void)sender; (void)path; (void)iface; (void)data;
+    if (g_strcmp0 (method, "GetInitialResultSet") == 0 || g_strcmp0 (method, "GetSubsearchResultSet") == 0) {
+        gchar **terms;
+        if (g_strcmp0 (method, "GetInitialResultSet") == 0) g_variant_get (params, "(^as)", &terms);
+        else g_variant_get (params, "(^as^as)", NULL, &terms);
+        GVariantBuilder builder;
+        g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+        GPtrArray *entries = load_entries ();
+        for (guint i = 0; i < entries->len; i++) {
+            OtpSearchEntry *e = g_ptr_array_index (entries, i);
+            if (entry_matches_terms (e, terms, g_strv_length(terms))) g_variant_builder_add (&builder, "s", e->id);
+        }
+        g_ptr_array_free (entries, TRUE);
+        g_dbus_method_invocation_return_value (inv, g_variant_new ("(as)", &builder));
+        g_strfreev (terms);
+    } else if (g_strcmp0 (method, "GetResultMetas") == 0) {
+        gchar **ids;
+        g_variant_get (params, "(^as)", &ids);
+        GVariantBuilder builder;
+        g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
+        GPtrArray *entries = load_entries ();
+        for (gsize j = 0; ids[j]; j++) {
+            for (guint i = 0; i < entries->len; i++) {
+                OtpSearchEntry *e = g_ptr_array_index (entries, i);
+                if (g_strcmp0 (e->id, ids[j]) == 0) {
+                    GVariantBuilder meta;
+                    g_variant_builder_init (&meta, G_VARIANT_TYPE ("a{sv}"));
+                    g_variant_builder_add (&meta, "{sv}", "id", g_variant_new_string (e->id));
+                    g_variant_builder_add (&meta, "{sv}", "name", g_variant_new_string (e->label));
+                    g_variant_builder_add (&meta, "{sv}", "description", g_variant_new_string (e->issuer));
+                    g_variant_builder_add (&meta, "{sv}", "icon", g_variant_new_string ("com.github.paolostivanin.OTPClient"));
+                    g_variant_builder_add_value (&builder, g_variant_builder_end (&meta));
+                }
+            }
+        }
+        g_ptr_array_free (entries, TRUE);
+        g_dbus_method_invocation_return_value (inv, g_variant_new ("(aa{sv})", &builder));
+        g_strfreev (ids);
+    } else if (g_strcmp0 (method, "ActivateResult") == 0) {
+        const gchar *id;
+        g_variant_get (params, "(&s^as u)", &id, NULL, NULL);
+        g_autofree gchar *otp = get_otp_for_id (id);
+        g_autofree gchar *label = NULL;
+        GPtrArray *entries = load_entries();
+        for (guint i = 0; i < entries->len; i++) {
+            OtpSearchEntry *e = g_ptr_array_index(entries, i);
+            if (g_strcmp0(e->id, id) == 0) { label = g_strdup(e->label); break; }
+        }
+        g_ptr_array_free(entries, TRUE);
+        send_notification (label, otp);
+        g_dbus_method_invocation_return_value (inv, NULL);
+    } else { g_dbus_method_invocation_return_value (inv, NULL); }
+}
+
+static void handle_krunner_call (GDBusConnection *conn, const gchar *sender, const gchar *path, const gchar *iface,
+                                const gchar *method, GVariant *params, GDBusMethodInvocation *inv, gpointer data) {
+    (void)conn; (void)sender; (void)path; (void)iface; (void)data;
+    if (g_strcmp0 (method, "Match") == 0) {
+        const gchar *query;
+        g_variant_get (params, "(&s)", &query);
+        GVariantBuilder builder;
+        g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(sssida{sv})"));
+        if (query && *query) {
+            g_auto(GStrv) terms = g_strsplit_set (query, " \t", -1);
+            gsize terms_len = g_strv_length (terms);
+            GPtrArray *entries = load_entries ();
+            for (guint i = 0; i < entries->len; i++) {
+                OtpSearchEntry *e = g_ptr_array_index (entries, i);
+                if (!entry_matches_terms (e, terms, terms_len)) continue;
+                GVariantBuilder props;
+                g_variant_builder_init (&props, G_VARIANT_TYPE ("a{sv}"));
+                g_autofree gchar *sub = (e->issuer && *e->issuer) ? g_strdup_printf ("%s • %s", e->issuer, e->otp_value) : g_strdup (e->otp_value);
+                g_variant_builder_add (&props, "{sv}", "subtext", g_variant_new_string (sub));
+                g_variant_builder_add (&props, "{sv}", "category", g_variant_new_string ("OTPClient"));
+                g_variant_builder_add (&builder, "(sssida{sv})", e->id, e->label, "com.github.paolostivanin.OTPClient", (gint32)0, (gdouble)1.0, &props);
+            }
+            g_ptr_array_free (entries, TRUE);
+        }
+        GVariant *res = g_variant_builder_end (&builder);
+        g_dbus_method_invocation_return_value (inv, g_variant_new_tuple (&res, 1));
+    } else if (g_strcmp0 (method, "Run") == 0) {
+        const gchar *id;
+        g_variant_get (params, "(&s&s)", &id, NULL);
+        g_autofree gchar *otp = get_otp_for_id (id);
+        g_autofree gchar *label = NULL;
+        GPtrArray *entries = load_entries();
+        for (guint i = 0; i < entries->len; i++) {
+            OtpSearchEntry *e = g_ptr_array_index(entries, i);
+            if (g_strcmp0(e->id, id) == 0) { label = g_strdup(e->label); break; }
+        }
+        g_ptr_array_free(entries, TRUE);
+        send_notification (label, otp);
+        g_dbus_method_invocation_return_value (inv, NULL);
+    } else if (g_strcmp0 (method, "Actions") == 0) {
+        GVariant *empty = g_variant_new_array (G_VARIANT_TYPE ("(sss)"), NULL, 0);
+        g_dbus_method_invocation_return_value (inv, g_variant_new_tuple (&empty, 1));
+    }
+}
+
+static const GDBusInterfaceVTable k_vtable = { handle_krunner_call, NULL, NULL, {0} };
+static const GDBusInterfaceVTable g_vtable = { handle_gnome_call, NULL, NULL, {0} };
+
+static void on_bus_acquired (GDBusConnection *conn, const gchar *name G_GNUC_UNUSED, gpointer data G_GNUC_UNUSED) {
+    g_autoptr(GError) error = NULL;
+    g_autoptr(GDBusNodeInfo) k_node = g_dbus_node_info_new_for_xml (krunner_introspection_xml, &error);
+    g_dbus_connection_register_object (conn, KRUNNER_PATH, k_node->interfaces[0], &k_vtable, NULL, NULL, NULL);
+    g_autoptr(GDBusNodeInfo) g_node = g_dbus_node_info_new_for_xml (gnome_introspection_xml, &error);
+    g_dbus_connection_register_object (conn, GNOME_PATH, g_node->interfaces[0], &g_vtable, NULL, NULL, NULL);
+}
+
+int main (int argc, char **argv) {
+    gboolean force_kde = FALSE, force_gnome = FALSE;
+    for (int i = 1; i < argc; i++) {
+        if (g_strcmp0 (argv[i], "--kde") == 0) force_kde = TRUE;
+        if (g_strcmp0 (argv[i], "--gnome") == 0) force_gnome = TRUE;
+    }
+    if (!get_search_provider_enabled ()) return 0;
+    if (!force_kde && !force_gnome) {
+        const gchar *desktop = g_getenv ("XDG_CURRENT_DESKTOP");
+        if (desktop) {
+            g_autofree gchar *dl = g_ascii_strdown (desktop, -1);
+            if (g_strstr_len (dl, -1, "kde") || g_strstr_len (dl, -1, "plasma")) force_kde = TRUE;
+            else if (g_strstr_len (dl, -1, "gnome")) force_gnome = TRUE;
+        }
+    }
+    if (force_kde) g_bus_own_name (G_BUS_TYPE_SESSION, KRUNNER_BUS, G_BUS_NAME_OWNER_FLAGS_NONE, on_bus_acquired, NULL, NULL, NULL, NULL);
+    if (force_gnome) g_bus_own_name (G_BUS_TYPE_SESSION, GNOME_BUS, G_BUS_NAME_OWNER_FLAGS_NONE, on_bus_acquired, NULL, NULL, NULL, NULL);
+    if (!force_kde && !force_gnome) return 0;
+    g_main_loop_run (g_main_loop_new (NULL, FALSE));
+    return 0;
+}


### PR DESCRIPTION
- Implement org.kde.krunner1 interface for Plasma 6
- Implement org.gnome.Shell.SearchProvider2 for GNOME Shell
- Add D-Bus service activation and metadata files
- Display TOTP/HOTP codes directly in search results
- Trigger system notifications on result activation
- Add config option to enable/disable search provider (default enabled)