### PR TITLE
fix: address multiple code quality and safety issues across common and GUI layers

### DIFF
--- a/src/common/authpro.c
+++ b/src/common/authpro.c
@@ -94,7 +94,7 @@ export_authpro (const gchar *export_path,
                 json_object_set(export_obj, "Issuer", json_object_get (db_obj, "issuer"));
             }
         }
-        const gchar *label = json_string_value (json_object_get (db_obj, "issuer"));
+        const gchar *label = json_string_value (json_object_get (db_obj, "label"));
         if (label != NULL) {
             json_object_set (export_obj, "Username", json_object_get (db_obj, "label"));
         }
@@ -103,14 +103,16 @@ export_authpro (const gchar *export_path,
         json_object_set (export_obj, "Ranking", json_integer (0));
         json_object_set (export_obj, "Icon", json_null());
         json_object_set (export_obj, "Pin", json_null());
-        if (g_ascii_strcasecmp (json_string_value (json_object_get (db_obj, "algo")), "SHA1") == 0) {
+        const gchar *algo = json_string_value (json_object_get (db_obj, "algo"));
+        if (algo != NULL && g_ascii_strcasecmp (algo, "SHA1") == 0) {
             json_object_set (export_obj, "Algorithm", json_integer (0));
-        } else if (g_ascii_strcasecmp (json_string_value (json_object_get (db_obj, "algo")), "SHA256") == 0) {
+        } else if (algo != NULL && g_ascii_strcasecmp (algo, "SHA256") == 0) {
             json_object_set (export_obj, "Algorithm", json_integer (1));
-        } else if (g_ascii_strcasecmp (json_string_value (json_object_get (db_obj, "algo")), "SHA512") == 0) {
+        } else if (algo != NULL && g_ascii_strcasecmp (algo, "SHA512") == 0) {
             json_object_set (export_obj, "Algorithm", json_integer (2));
         }
-        if (g_ascii_strcasecmp (json_string_value (json_object_get (db_obj, "type")), "TOTP") == 0) {
+        const gchar *type = json_string_value (json_object_get (db_obj, "type"));
+        if (type != NULL && g_ascii_strcasecmp (type, "TOTP") == 0) {
             json_object_set (export_obj, "Period", json_object_get (db_obj, "period"));
             json_object_set (export_obj, "Counter", json_integer (0));
             json_object_set (export_obj, "Type", is_steam ? json_integer (4) : json_integer (2));

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -220,14 +220,14 @@ get_data_from_encrypted_backup (const gchar       *path,
             break;
     }
 
-    guchar salt[salt_size];
+    g_autofree guchar *salt = g_malloc0 (salt_size);
     if (g_input_stream_read (G_INPUT_STREAM (in_stream), salt, salt_size, NULL, err) == -1) {
         g_object_unref (in_stream);
         g_object_unref (in_file);
         return NULL;
     }
 
-    guchar iv[iv_size];
+    g_autofree guchar *iv = g_malloc0 (iv_size);
     if (g_input_stream_read (G_INPUT_STREAM (in_stream), iv, iv_size, NULL, err) == -1) {
         g_object_unref (in_stream);
         g_object_unref (in_file);
@@ -240,7 +240,7 @@ get_data_from_encrypted_backup (const gchar       *path,
         g_object_unref (in_file);
         return NULL;
     }
-    guchar tag[tag_size];
+    g_autofree guchar *tag = g_malloc0 (tag_size);
     if (g_input_stream_read (G_INPUT_STREAM (in_stream), tag, tag_size, NULL, err) == -1) {
         g_object_unref (in_stream);
         g_object_unref (in_file);
@@ -405,8 +405,6 @@ build_json_obj (const gchar *type,
     json_object_set (obj, "secret", json_string (acc_key));
     json_object_set (obj, "digits", json_integer (digits));
     json_object_set (obj, "algo", json_string (algo));
-
-    json_object_set (obj, "secret", json_string (acc_key));
 
     if (g_ascii_strcasecmp (type, "TOTP") == 0) {
         json_object_set (obj, "period", json_integer (period));

--- a/src/common/db-common.c
+++ b/src/common/db-common.c
@@ -163,9 +163,9 @@ add_otps_to_db (GSList       *otps,
     for (guint i = 0; i < list_len; i++) {
         otp_t *otp = g_slist_nth_data (otps, i);
         obj = build_json_obj (otp->type, otp->account_name, otp->issuer, otp->secret, otp->digits, otp->algo, otp->period, otp->counter);
-        guint hash = json_object_get_hash (obj);
-        if (g_slist_find_custom (db_data->objects_hash, GUINT_TO_POINTER(hash), check_duplicate) == NULL) {
-            db_data->objects_hash = g_slist_append (db_data->objects_hash, g_memdup2 (&hash, sizeof (guint)));
+        guint32 hash = json_object_get_hash (obj);
+        if (g_slist_find_custom (db_data->objects_hash, GUINT_TO_POINTER((guint)hash), check_duplicate) == NULL) {
+            db_data->objects_hash = g_slist_append (db_data->objects_hash, g_memdup2 (&hash, sizeof (guint32)));
             db_data->data_to_add = g_slist_append (db_data->data_to_add, obj);
         } else {
             g_print ("[INFO] Duplicate element not added\n");
@@ -178,8 +178,8 @@ gint
 check_duplicate (gconstpointer data,
                  gconstpointer user_data)
 {
-    guint list_elem = *(guint *)data;
-    if (list_elem == GPOINTER_TO_UINT(user_data)) {
+    guint32 list_elem = *(guint32 *)data;
+    if (list_elem == (guint32)GPOINTER_TO_UINT(user_data)) {
         return 0;
     }
     return -1;

--- a/src/gui/password-cb.c
+++ b/src/gui/password-cb.c
@@ -1,5 +1,6 @@
 #include <gtk/gtk.h>
 #include <gcrypt.h>
+#include <string.h>
 #include "gui-misc.h"
 #include "message-dialogs.h"
 #include "get-builder.h"
@@ -102,9 +103,9 @@ prompt_for_password (AppData        *app_data,
     gchar *pwd = NULL;
     if (entry_widgets->pwd != NULL) {
         gcry_free (current_key);
-        gsize len = g_utf8_strlen (entry_widgets->pwd, -1) + 1;
+        gsize len = strlen (entry_widgets->pwd) + 1;
         pwd = gcry_calloc_secure (len, 1);
-        strncpy (pwd, entry_widgets->pwd, len);
+        memcpy (pwd, entry_widgets->pwd, len);
         gcry_free (entry_widgets->pwd);
     }
     if (entry_widgets->cur_pwd != NULL) {
@@ -164,9 +165,9 @@ password_cb (GtkWidget  *entry,
              gpointer   *pwd)
 {
     const gchar *text = gtk_entry_get_text (GTK_ENTRY(entry));
-    gsize len = g_utf8_strlen (text, -1) + 1;
+    gsize len = strlen (text) + 1;
     *pwd = gcry_calloc_secure (len, 1);
-    strncpy (*pwd, text, len);
+    memcpy (*pwd, text, len);
     reset_entry_after_submit (entry);
     GtkWidget *top_level = gtk_widget_get_toplevel (entry);
     gtk_dialog_response (GTK_DIALOG (top_level), GTK_RESPONSE_CLOSE);


### PR DESCRIPTION
- parse-uri: guard all json_string_value() results against NULL in get_otpauth_uri; fix g_utf8_strdown() memory leak; fix get_otpauth_data to not pre-allocate a gcrypt secure buffer before passing to g_file_get_contents (caused a secure-memory leak and replaced the pointer with non-secure memory); remove spurious double g_set_error(); replace silent guint8-truncating casts for period/digits with validated range checks
- authpro: fix copy-paste bug where "issuer" key was read instead of "label" when building the Username export field; guard algo and type comparisons against NULL json_string_value() returns
- common: remove duplicate json_object_set() for "secret" in build_json_obj; replace C11-optional VLA stack buffers (salt, iv, tag) in get_data_from_encrypted_backup with g_autofree heap allocations
- db-common: unify hash type to guint32 in add_otps_to_db and check_duplicate (was mixing guint and guint32 across load_db and add_otps_to_db, causing potential UB on ILP64 platforms)
- aegis: add missing g_set_error() to five error paths in get_otps_from_encrypted_backup that returned NULL without setting the error; free salt and key_nonce on kdf_derive failure in export_aegis; guard type and algo fields against NULL before g_ascii_strcasecmp in parse_aegis_json_data
- password-cb: replace g_utf8_strlen+strncpy with strlen+memcpy when copying passwords into gcrypt secure buffers (character count vs byte count mismatch caused under-allocation for multibyte UTF-8 passwords)