### PR TITLE
chore: improve CMakeLists.txt, README.md and SECURITY.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(IS_FLATPAK "Use flatpak app's config folder to store the database" OFF)
 
 set(COMMON_C_OPTIONS
         -Wall -Wextra -O3 -Wformat=2 -Wmissing-format-attribute -fstack-protector-strong
-        -Wundef -Wmissing-format-attribute -fdiagnostics-color=always
+        -Wundef -fdiagnostics-color=always
         -Wstrict-prototypes -Wunreachable-code -Wchar-subscripts
         -Wwrite-strings -Wpointer-arith -Wbad-function-cast -Wcast-align
         -Werror=format-security -Werror=implicit-function-declaration -Wno-sign-compare
@@ -34,7 +34,7 @@ set(COMMON_COMPILE_DEFINITIONS
 
 set(COMMON_LINK_OPTIONS)
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     list(APPEND COMMON_C_OPTIONS -fPIE)
     list(APPEND COMMON_LINK_OPTIONS -pie)
 endif()
@@ -49,7 +49,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND COMMON_LINK_OPTIONS
-            "-Wl,--no-add-needed"
+            "-Wl,--no-copy-dt-needed-entries"
             "-Wl,--as-needed"
             "-Wl,--no-undefined"
             "-Wl,-z,relro,-z,now"
@@ -57,7 +57,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 find_package(PkgConfig REQUIRED)
-find_package(Protobuf 3.6.0 REQUIRED)
 pkg_check_modules(GCRYPT REQUIRED IMPORTED_TARGET libgcrypt>=1.10.1)
 pkg_check_modules(COTP REQUIRED IMPORTED_TARGET cotp>=3.0.0)
 pkg_check_modules(PNG REQUIRED IMPORTED_TARGET libpng>=1.6.30)
@@ -109,9 +108,9 @@ if(BUILD_GUI)
     )
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "otpclient")
 
-    install(TARGETS ${PROJECT_NAME} DESTINATION bin)
-    install(FILES data/com.github.paolostivanin.OTPClient.desktop DESTINATION share/applications)
-    install(FILES man/otpclient.1 DESTINATION share/man/man1)
+    install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES data/com.github.paolostivanin.OTPClient.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+    install(FILES man/otpclient.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
     set(GUI_UI_FILES
             src/gui/ui/otpclient.ui
@@ -120,13 +119,13 @@ if(BUILD_GUI)
             src/gui/ui/security_settings.ui
             src/gui/ui/shortcuts.ui
     )
-    install(FILES ${GUI_UI_FILES} DESTINATION share/otpclient)
+    install(FILES ${GUI_UI_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/otpclient)
 
     set(GUI_ICON_FILES
             data/icons/com.github.paolostivanin.OTPClient.svg
             data/icons/com.github.paolostivanin.OTPClient-symbolic.svg
     )
-    install(FILES ${GUI_ICON_FILES} DESTINATION share/icons/hicolor/scalable/apps)
+    install(FILES ${GUI_ICON_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
 endif ()
 
 if(BUILD_CLI)
@@ -137,8 +136,8 @@ if(BUILD_CLI)
     )
     set_target_properties(${PROJECT_NAME}-cli PROPERTIES OUTPUT_NAME "otpclient-cli")
 
-    install(TARGETS ${PROJECT_NAME}-cli DESTINATION bin)
-    install(FILES man/otpclient-cli.1 DESTINATION share/man/man1)
+    install(TARGETS ${PROJECT_NAME}-cli DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES man/otpclient-cli.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 endif()
 
 if(BUILD_SEARCH_PROVIDER)
@@ -148,16 +147,16 @@ if(BUILD_SEARCH_PROVIDER)
             PkgConfig::GTK3
             ${COMMON_LIBS}
     )
-    install(TARGETS ${PROJECT_NAME}-search-provider DESTINATION bin)
+    install(TARGETS ${PROJECT_NAME}-search-provider DESTINATION ${CMAKE_INSTALL_BINDIR})
     # GNOME Search Provider metadata
-    install(FILES data/gnome-shell/search-providers/com.github.paolostivanin.OTPClient.SearchProvider.ini DESTINATION share/gnome-shell/search-providers)
+    install(FILES data/gnome-shell/search-providers/com.github.paolostivanin.OTPClient.SearchProvider.ini DESTINATION ${CMAKE_INSTALL_DATADIR}/gnome-shell/search-providers)
 
     # D-Bus Service activation files (allows KRunner/GNOME to launch the binary on demand)
-    install(FILES data/dbus-1/services/com.github.paolostivanin.OTPClient.SearchProvider.service DESTINATION share/dbus-1/services)
-    install(FILES data/dbus-1/services/com.github.paolostivanin.OTPClient.KRunner.service DESTINATION share/dbus-1/services)
+    install(FILES data/dbus-1/services/com.github.paolostivanin.OTPClient.SearchProvider.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services)
+    install(FILES data/dbus-1/services/com.github.paolostivanin.OTPClient.KRunner.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services)
 
     # KDE Plasma 6 KRunner Metadata
-    install(FILES data/krunner/com.github.paolostivanin.OTPClient.KRunner.desktop DESTINATION share/krunner/dbusplugins)
+    install(FILES data/krunner/com.github.paolostivanin.OTPClient.KRunner.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/krunner/dbusplugins)
 endif()
 
-install(FILES data/com.github.paolostivanin.OTPClient.appdata.xml DESTINATION share/metainfo)
+install(FILES data/com.github.paolostivanin.OTPClient.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)

--- a/README.md
+++ b/README.md
@@ -11,20 +11,19 @@
 Highly secure and easy to use GTK+ software for two-factor authentication that supports both Time-based One-time Passwords (TOTP) and HMAC-Based One-Time Passwords (HOTP).
 
 ## Requirements
-| Name                                               | Min Version |
-|----------------------------------------------------|-------------|
-| GTK+                                               | 3.24        |
-| Glib                                               | 2.68.0      |
-| jansson                                            | 2.12        |
-| libgcrypt                                          | 1.10.1      |
-| libpng                                             | 1.6.30      |
-| [libcotp](https://github.com/paolostivanin/libcotp) | 3.0.0      |
-| zbar                                               | 0.20        |
-| protobuf-c                                         | 1.3.0       |
-| protobuf                                           | 3.6.0       |
-| uuid                                               | 2.34        |
-| libsecret                                          | 0.20        |
-| qrencode                                           | 4.0.2       |
+| Name                                                | Min Version |
+|-----------------------------------------------------|-------------|
+| GTK+                                                | 3.24        |
+| Glib                                                | 2.68.0      |
+| jansson                                             | 2.12        |
+| libgcrypt                                           | 1.10.1      |
+| libpng                                              | 1.6.30      |
+| [libcotp](https://github.com/paolostivanin/libcotp) | 3.0.0       |
+| zbar                                                | 0.20        |
+| protobuf-c                                          | 1.3.0       |
+| uuid                                                | 2.34        |
+| libsecret                                           | 0.20        |
+| qrencode                                            | 4.0.2       |
 
 :warning: Please note that the memlock value should be `>= 64 MB`. Any value less than this may cause issues when dealing with tens of tokens (especially when importing from third parties backups).
 See this [wiki section](https://github.com/paolostivanin/OTPClient/wiki/Secure-Memory-Limitations) for info on how to check the current value and set, if needed, a higher one.
@@ -65,7 +64,7 @@ git clone https://github.com/paolostivanin/OTPClient.git
 cd OTPClient
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr ..
-make
+make -j$(nproc)
 sudo make install
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,12 @@
 
 The following list describes whether a version is eligible or not for security updates.
 
-| Version | Supported          | EOL         |
-|---------|--------------------|-------------|
+| Version | Supported              | EOL         |
+|---------|------------------------|-------------|
 | 4.4.x   | :white_check_mark: Yes | -           |
 | 4.3.x   | :white_check_mark: Yes | 27-Feb-2026 |
-| 4.2.x   | :white_check_mark: Yes | 20-Feb-2026 |
-| 4.1.x   | :white_check_mark: Yes | 06-Feb-2026 |
+| 4.2.x   | :x: No                 | 20-Feb-2026 |
+| 4.1.x   | :x: No                 | 06-Feb-2026 |
 | 4.0.x   | :x: No                 | 30-Jun-2025 |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
- Remove duplicate -Wmissing-format-attribute compiler flag
- Remove unused find_package(Protobuf) call (protobuf-c is found via pkg_check_modules)
- Extend PIE flags (-fPIE/-pie) to Clang in addition to GCC
- Replace deprecated -Wl,--no-add-needed with --no-copy-dt-needed-entries
- Use GNUInstallDirs variables throughout all install() calls
- Drop protobuf from requirements table (C++ compiler not needed at build time)
- Add -j$(nproc) to manual build instructions
- Mark 4.1.x and 4.2.x as unsupported (EOL dates have passed)