### PR TITLE
refactor: modernise application and window layer to GTK idioms

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ The following list describes whether a version is eligible or not for security u
 | Version | Supported              | EOL         |
 |---------|------------------------|-------------|
 | 4.4.x   | :white_check_mark: Yes | -           |
-| 4.3.x   | :white_check_mark: Yes | 27-Feb-2026 |
+| 4.3.x   | :white_check_mark: Yes | -           |
 | 4.2.x   | :x: No                 | 20-Feb-2026 |
 | 4.1.x   | :x: No                 | 06-Feb-2026 |
 | 4.0.x   | :x: No                 | 30-Jun-2025 |

--- a/src/gui/config-misc.c
+++ b/src/gui/config-misc.c
@@ -1,0 +1,66 @@
+#include <gtk/gtk.h>
+#include "config-misc.h"
+
+static void store_data (const gchar *param1_name,
+                        gint         param1_value,
+                        const gchar *param2_name,
+                        gint         param2_value);
+
+void
+save_sort_order (GtkTreeView *tree_view)
+{
+    gint id;
+    GtkSortType order;
+    GtkTreeModel *model = gtk_tree_view_get_model (tree_view);
+    if (model == NULL) {
+        return;
+    }
+    if (GTK_IS_TREE_MODEL_FILTER (model)) {
+        model = gtk_tree_model_filter_get_model (GTK_TREE_MODEL_FILTER (model));
+    }
+    if (!GTK_IS_TREE_SORTABLE (model)) {
+        return;
+    }
+    gtk_tree_sortable_get_sort_column_id (GTK_TREE_SORTABLE (model), &id, &order);
+    if (id >= 0) {
+        store_data ("column_id", id, "sort_order", order);
+    }
+}
+
+void
+save_window_size (gint width,
+                  gint height)
+{
+    store_data ("window_width", width, "window_height", height);
+}
+
+static void
+store_data (const gchar *param1_name,
+            gint         param1_value,
+            const gchar *param2_name,
+            gint         param2_value)
+{
+    GError *err = NULL;
+    GKeyFile *kf = g_key_file_new ();
+    gchar *cfg_file_path;
+#ifndef IS_FLATPAK
+    cfg_file_path = g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL);
+#else
+    cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
+#endif
+    if (g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
+        if (!g_key_file_load_from_file (kf, cfg_file_path, G_KEY_FILE_NONE, &err)) {
+            g_printerr ("%s\n", err->message);
+            g_clear_error (&err);
+        } else {
+            g_key_file_set_integer (kf, "config", param1_name, param1_value);
+            g_key_file_set_integer (kf, "config", param2_name, param2_value);
+            if (!g_key_file_save_to_file (kf, cfg_file_path, &err)) {
+                g_printerr ("%s\n", err->message);
+                g_clear_error (&err);
+            }
+        }
+    }
+    g_key_file_free (kf);
+    g_free (cfg_file_path);
+}

--- a/src/gui/config-misc.h
+++ b/src/gui/config-misc.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+void save_sort_order  (GtkTreeView *tree_view);
+
+void save_window_size (gint         width,
+                       gint         height);
+
+G_END_DECLS

--- a/src/gui/data.h
+++ b/src/gui/data.h
@@ -12,6 +12,8 @@
 G_BEGIN_DECLS
 
 typedef struct app_data_t {
+    /* Non-owning references to the builders held by OtpclientWindow.
+     * Do NOT g_object_unref() these — the window's dispose handles that. */
     GtkBuilder *builder;
     GtkBuilder *add_popover_builder;
     GtkBuilder *settings_popover_builder;

--- a/src/gui/otpclient-application.c
+++ b/src/gui/otpclient-application.c
@@ -11,7 +11,6 @@
 #include "../common/import-export.h"
 #include "message-dialogs.h"
 #include "password-cb.h"
-#include "get-builder.h"
 #include "liststore-misc.h"
 #include "lock-app.h"
 #include "change-db-cb.h"
@@ -34,37 +33,46 @@
 #endif
 
 #ifndef IS_FLATPAK
-static gchar     *get_db_path               (AppData            *app_data);
+static gchar   *get_db_path            (AppData            *app_data);
 #endif
 
-static void       set_config_data           (gint               *width,
-                                             gint               *height,
-                                             AppData            *app_data);
+static void     set_config_data        (gint               *width,
+                                        gint               *height,
+                                        AppData            *app_data);
 
-static void       set_open_db_action        (GtkWidget          *btn,
-                                             gpointer            user_data);
+static void     set_open_db_action     (GtkWidget          *btn,
+                                        gpointer            user_data);
 
-static void       init_app_defaults         (AppData            *app_data);
+static void     init_app_defaults      (AppData            *app_data);
 
-static void       init_db_defaults          (AppData            *app_data);
+static void     init_db_defaults       (AppData            *app_data);
 
-static void       cleanup_app_data          (AppData            *app_data);
+static void     cleanup_app_data       (AppData            *app_data);
 
-static void       otpclient_application_shutdown (GApplication *app);
+static void     otpclient_application_shutdown (GApplication *app);
 
-static void       load_validity_colors      (GKeyFile           *kf,
-                                             AppData            *app_data);
+static void     load_validity_colors   (GKeyFile           *kf,
+                                        AppData            *app_data);
+
+/* Activation helpers */
+static gboolean resolve_db_path        (GApplication       *app,
+                                        AppData            *app_data);
+
+static gboolean load_db_with_password  (GApplication       *app,
+                                        AppData            *app_data,
+                                        gint32              memlock_value);
+
+static void     setup_ui_and_timers    (GApplication       *app,
+                                        AppData            *app_data);
 
 struct _OtpclientApplication {
-    GtkApplication parent_instance;
-    AppData *app_data;
-};
-
-struct _OtpclientApplicationClass {
-    GtkApplicationClass parent_class;
+    GtkApplication  parent_instance;
+    AppData        *app_data;
 };
 
 G_DEFINE_TYPE (OtpclientApplication, otpclient_application, GTK_TYPE_APPLICATION)
+
+/* ── activate ──────────────────────────────────────────────────────────── */
 
 static void
 otpclient_application_activate (GApplication *app)
@@ -75,24 +83,22 @@ otpclient_application_activate (GApplication *app)
         return;
     }
 
-    gint32 memlock_value = 0;
+    gint32 memlock_value    = 0;
     gint32 memlock_ret_value = set_memlock_value (&memlock_value);
 
     AppData *app_data = g_new0 (AppData, 1);
     init_app_defaults (app_data);
+
     g_type_ensure (OTPCLIENT_TYPE_WINDOW);
-    app_data->builder = get_builder_from_partial_path (UI_PARTIAL_PATH);
-    app_data->add_popover_builder = get_builder_from_partial_path (AP_PARTIAL_PATH);
-    app_data->settings_popover_builder = get_builder_from_partial_path (SP_PARTIAL_PATH);
 
     app_data->db_data = g_new0 (DatabaseData, 1);
     init_db_defaults (app_data);
 
-    gint width = 0;
-    gint height = 0;
+    gint width = 0, height = 0;
     set_config_data (&width, &height, app_data);
 
-    OtpclientWindow *window = otpclient_window_new (GTK_APPLICATION (app), width, height, app_data);
+    OtpclientWindow *window = otpclient_window_new (GTK_APPLICATION (app),
+                                                     width, height, app_data);
     if (window == NULL) {
         g_printerr ("%s\n", _("Couldn't locate the ui file, exiting..."));
         cleanup_app_data (app_data);
@@ -101,8 +107,11 @@ otpclient_application_activate (GApplication *app)
     }
 
     if (memlock_ret_value == MEMLOCK_ERR) {
-        gchar *msg = g_strdup_printf (_("Couldn't get the memlock value, therefore secure memory cannot be allocated. Please have a look at the"
-                                        "<a href=\"https://github.com/paolostivanin/OTPClient/wiki/Secure-Memory-Limitations\">secure memory</a> wiki page before re-running OTPClient."));
+        gchar *msg = g_strdup_printf (_(
+            "Couldn't get the memlock value, therefore secure memory cannot be allocated. "
+            "Please have a look at the "
+            "<a href=\"https://github.com/paolostivanin/OTPClient/wiki/Secure-Memory-Limitations\">"
+            "secure memory</a> wiki page before re-running OTPClient."));
         show_message_dialog (app_data->main_window, msg, GTK_MESSAGE_ERROR);
         g_free (msg);
         cleanup_app_data (app_data);
@@ -119,17 +128,51 @@ otpclient_application_activate (GApplication *app)
         return;
     }
 
+    if (!resolve_db_path (app, app_data)) {
+        cleanup_app_data (app_data);
+        g_application_quit (app);
+        return;
+    }
+
+    app_data->db_data->max_file_size_from_memlock = memlock_value;
+    app_data->db_data->objects_hash  = NULL;
+    app_data->db_data->data_to_add   = NULL;
+    /* Subtract 3 s so "last_hotp" is valid from the very first run */
+    app_data->db_data->last_hotp_update =
+        g_date_time_add_seconds (g_date_time_new_now_local (),
+                                 -(G_TIME_SPAN_SECOND * HOTP_RATE_LIMIT_IN_SEC));
+
+    if (!load_db_with_password (app, app_data, memlock_value)) {
+        cleanup_app_data (app_data);
+        g_application_quit (app);
+        return;
+    }
+
+    setup_ui_and_timers (app, app_data);
+
+    self->app_data = app_data;
+
+    gtk_widget_show_all (app_data->main_window);
+    /* search_entry has no_show_all set; it stays hidden until Ctrl+F */
+}
+
+/* ── resolve_db_path ───────────────────────────────────────────────────── */
+
+static gboolean
+resolve_db_path (GApplication *app UNUSED,
+                 AppData      *app_data)
+{
 #ifdef IS_FLATPAK
-    // Check if a path is already set in the config
     GKeyFile *kf = get_kf_ptr ();
     if (kf != NULL) {
         gchar *db_path = g_key_file_get_string (kf, "config", "db_path", NULL);
         if (db_path != NULL) {
             app_data->db_data->db_path = db_path;
         } else {
-            // Use the default path only if no path is set in config
-            app_data->db_data->db_path = g_build_filename (g_get_user_data_dir (), "otpclient-db.enc", NULL);
-            gchar *cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
+            app_data->db_data->db_path =
+                g_build_filename (g_get_user_data_dir (), "otpclient-db.enc", NULL);
+            gchar *cfg_file_path =
+                g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
             if (g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
                 g_key_file_set_string (kf, "config", "db_path", app_data->db_data->db_path);
                 g_key_file_save_to_file (kf, cfg_file_path, NULL);
@@ -138,10 +181,10 @@ otpclient_application_activate (GApplication *app)
         }
         g_key_file_free (kf);
     } else {
-        // If no config exists yet, use the default path
-        app_data->db_data->db_path = g_build_filename (g_get_user_data_dir (), "otpclient-db.enc", NULL);
-        // Create a minimal config
-        gchar *cfg_file_path = g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
+        app_data->db_data->db_path =
+            g_build_filename (g_get_user_data_dir (), "otpclient-db.enc", NULL);
+        gchar *cfg_file_path =
+            g_build_filename (g_get_user_data_dir (), "otpclient.cfg", NULL);
         if (!g_file_test (cfg_file_path, G_FILE_TEST_EXISTS)) {
             GKeyFile *new_kf = g_key_file_new ();
             g_key_file_set_string (new_kf, "config", "db_path", app_data->db_data->db_path);
@@ -150,102 +193,138 @@ otpclient_application_activate (GApplication *app)
         }
         g_free (cfg_file_path);
     }
+    return TRUE;
 #else
-    if (!g_file_test (g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL), G_FILE_TEST_EXISTS)) {
-        app_data->diag_rcdb = GTK_WIDGET (gtk_builder_get_object (app_data->builder, "dialog_rcdb_id"));
-        GtkWidget *restore_btn = GTK_WIDGET (gtk_builder_get_object (app_data->builder, "diag_rc_restoredb_btn_id"));
-        GtkWidget *create_btn = GTK_WIDGET (gtk_builder_get_object (app_data->builder, "diag_rc_createdb_btn_id"));
+    if (!g_file_test (g_build_filename (g_get_user_config_dir (), "otpclient.cfg", NULL),
+                      G_FILE_TEST_EXISTS)) {
+        app_data->diag_rcdb =
+            GTK_WIDGET (gtk_builder_get_object (app_data->builder, "dialog_rcdb_id"));
+        GtkWidget *restore_btn =
+            GTK_WIDGET (gtk_builder_get_object (app_data->builder, "diag_rc_restoredb_btn_id"));
+        GtkWidget *create_btn =
+            GTK_WIDGET (gtk_builder_get_object (app_data->builder, "diag_rc_createdb_btn_id"));
         g_signal_connect (restore_btn, "clicked", G_CALLBACK (set_open_db_action), app_data);
-        g_signal_connect (create_btn, "clicked", G_CALLBACK (set_open_db_action), app_data);
+        g_signal_connect (create_btn,  "clicked", G_CALLBACK (set_open_db_action), app_data);
 
         gint response = gtk_dialog_run (GTK_DIALOG (app_data->diag_rcdb));
         switch (response) {
             case GTK_RESPONSE_CANCEL:
             default:
                 gtk_widget_destroy (app_data->diag_rcdb);
-                cleanup_app_data (app_data);
-                g_application_quit (app);
-                return;
+                return FALSE;
             case GTK_RESPONSE_OK:
                 gtk_widget_destroy (app_data->diag_rcdb);
         }
     }
 
     app_data->db_data->db_path = get_db_path (app_data);
-    if (app_data->db_data->db_path == NULL) {
-        cleanup_app_data (app_data);
-        g_application_quit (app);
-        return;
-    }
+    return app_data->db_data->db_path != NULL;
 #endif
+}
 
-    app_data->db_data->max_file_size_from_memlock = memlock_value;
-    app_data->db_data->objects_hash = NULL;
-    app_data->db_data->data_to_add = NULL;
-    // subtract 3 seconds from the current time. Needed for "last_hotp" to be set on the first run
-    app_data->db_data->last_hotp_update = g_date_time_add_seconds (g_date_time_new_now_local (), -(G_TIME_SPAN_SECOND * HOTP_RATE_LIMIT_IN_SEC));
+/* ── load_db_with_password ─────────────────────────────────────────────── */
 
-    if (app_data->use_secret_service == TRUE) {
-        gchar *pwd = secret_password_lookup_sync (OTPCLIENT_SCHEMA, NULL, NULL, "string", "main_pwd", NULL);
-        if (pwd == NULL) {
-            g_printerr ("%s\n", _("Couldn't find the password in the secret service."));
-            goto retry;
-        }
-        app_data->db_data->key_stored = TRUE;
-        app_data->db_data->key = secure_strdup (pwd);
-        secret_password_free (pwd);
-    } else {
-        retry:
-        app_data->db_data->key = prompt_for_password (app_data, NULL, NULL, FALSE);
-        if (app_data->db_data->key == NULL) {
-            retry_change_file:
-            if (change_file (app_data) == QUIT_APP) {
-                cleanup_app_data (app_data);
-                g_application_quit (app);
-                return;
-            }
-            goto retry_change_file;
-        }
-    }
-
-    if (get_file_size (app_data->db_data->db_path) > (goffset) (app_data->db_data->max_file_size_from_memlock * SECMEM_SIZE_THRESHOLD_RATIO)) {
+static gboolean
+load_db_with_password (GApplication *app UNUSED,
+                       AppData      *app_data,
+                       gint32        memlock_value)
+{
+    if (get_file_size (app_data->db_data->db_path) >
+            (goffset) (app_data->db_data->max_file_size_from_memlock * SECMEM_SIZE_THRESHOLD_RATIO)) {
         gchar *msg = g_strdup_printf (_(
-            "Your system's secure memory limit (memlock: %d bytes) is not enough to securely load the database into memory.\n"
+            "Your system's secure memory limit (memlock: %d bytes) is not enough to securely "
+            "load the database into memory.\n"
             "You need to increase your system's memlock limit by following the instructions on our "
-            "<a href=\"https://github.com/paolostivanin/OTPClient/wiki/Secure-Memory-Limitations\">secure memory wiki page</a>.\n"
-            "This requires administrator privileges and is a system-wide setting that OTPClient cannot change automatically."
-        ), memlock_value);
+            "<a href=\"https://github.com/paolostivanin/OTPClient/wiki/Secure-Memory-Limitations\">"
+            "secure memory wiki page</a>.\n"
+            "This requires administrator privileges and is a system-wide setting that OTPClient "
+            "cannot change automatically."),
+            memlock_value);
         g_printerr ("%s\n", msg);
         g_free (msg);
-        cleanup_app_data (app_data);
-        g_application_quit (app);
-        return;
+        return FALSE;
+    }
+
+    if (app_data->use_secret_service) {
+        gchar *pwd = secret_password_lookup_sync (OTPCLIENT_SCHEMA, NULL, NULL,
+                                                   "string", "main_pwd", NULL);
+        if (pwd != NULL) {
+            app_data->db_data->key_stored = TRUE;
+            app_data->db_data->key = secure_strdup (pwd);
+            secret_password_free (pwd);
+        } else {
+            g_printerr ("%s\n", _("Couldn't find the password in the secret service."));
+            /* Fall through to manual password prompt */
+            app_data->use_secret_service = FALSE;
+        }
     }
 
     GError *err = NULL;
-    load_db (app_data->db_data, &err);
-    if (err != NULL && !g_error_matches (err, missing_file_gquark (), MISSING_FILE_ERRCODE)) {
-        show_message_dialog (app_data->main_window, err->message, GTK_MESSAGE_ERROR);
-        g_clear_pointer (&app_data->db_data->key, gcry_free);
-        if (g_error_matches (err, memlock_error_gquark (), MEMLOCK_ERRCODE)) {
-            cleanup_app_data (app_data);
+
+    if (!app_data->use_secret_service) {
+        /* Prompt until the user provides a valid password or opts to change file */
+        do {
+            g_clear_pointer (&app_data->db_data->key, gcry_free);
+            app_data->db_data->key = prompt_for_password (app_data, NULL, NULL, FALSE);
+
+            if (app_data->db_data->key == NULL) {
+                /* User cancelled — let them switch to a different database file */
+                gint change_res;
+                do {
+                    change_res = change_file (app_data);
+                } while (change_res != QUIT_APP && change_res != CHANGE_OK);
+
+                if (change_res == QUIT_APP) {
+                    return FALSE;
+                }
+                /* New file selected; loop back and prompt for its password */
+                continue;
+            }
+
             g_clear_error (&err);
-            g_application_quit (app);
-            return;
+            load_db (app_data->db_data, &err);
+
+            if (err == NULL ||
+                g_error_matches (err, missing_file_gquark (), MISSING_FILE_ERRCODE)) {
+                break;
+            }
+
+            show_message_dialog (app_data->main_window, err->message, GTK_MESSAGE_ERROR);
+            g_clear_pointer (&app_data->db_data->key, gcry_free);
+
+            if (g_error_matches (err, memlock_error_gquark (), MEMLOCK_ERRCODE)) {
+                g_clear_error (&err);
+                return FALSE;
+            }
+            g_clear_error (&err);
+            /* Wrong password or other recoverable error — prompt again */
+        } while (TRUE);
+    } else {
+        load_db (app_data->db_data, &err);
+        if (err != NULL &&
+            !g_error_matches (err, missing_file_gquark (), MISSING_FILE_ERRCODE)) {
+            show_message_dialog (app_data->main_window, err->message, GTK_MESSAGE_ERROR);
+            g_clear_error (&err);
+            return FALSE;
         }
-        g_clear_error (&err);
-        goto retry;
     }
 
-    if (app_data->use_secret_service == TRUE && app_data->db_data->key_stored == FALSE) {
-        secret_password_store (OTPCLIENT_SCHEMA, SECRET_COLLECTION_DEFAULT, "main_pwd", app_data->db_data->key, NULL, on_password_stored, NULL, "string", "main_pwd", NULL);
+    if (app_data->use_secret_service && !app_data->db_data->key_stored) {
+        secret_password_store (OTPCLIENT_SCHEMA, SECRET_COLLECTION_DEFAULT,
+                               "main_pwd", app_data->db_data->key,
+                               NULL, on_password_stored, NULL,
+                               "string", "main_pwd", NULL);
     }
 
-    if (g_error_matches (err, missing_file_gquark(), MISSING_FILE_ERRCODE)) {
-        const gchar *msg = _("This is the first time you run OTPClient, so you need to <b>add</b> or <b>import</b> some tokens.\n"
-        "- to <b>add</b> tokens, please click the + button on the <b>top left</b>.\n"
-        "- to <b>import</b> existing tokens, please click the menu button <b>on the top right</b>.\n"
-        "\nIf you need more info, please visit the <a href=\"https://github.com/paolostivanin/OTPClient/wiki\">project's wiki</a>");
+    if (g_error_matches (err, missing_file_gquark (), MISSING_FILE_ERRCODE)) {
+        const gchar *msg = _(
+            "This is the first time you run OTPClient, so you need to <b>add</b> or "
+            "<b>import</b> some tokens.\n"
+            "- to <b>add</b> tokens, please click the + button on the <b>top left</b>.\n"
+            "- to <b>import</b> existing tokens, please click the menu button "
+            "<b>on the top right</b>.\n"
+            "\nIf you need more info, please visit the "
+            "<a href=\"https://github.com/paolostivanin/OTPClient/wiki\">project's wiki</a>");
         show_message_dialog (app_data->main_window, msg, GTK_MESSAGE_INFO);
         GError *tmp_err = NULL;
         update_db (app_data->db_data, &tmp_err);
@@ -253,6 +332,16 @@ otpclient_application_activate (GApplication *app)
         g_clear_error (&tmp_err);
     }
 
+    g_clear_error (&err);
+    return TRUE;
+}
+
+/* ── setup_ui_and_timers ───────────────────────────────────────────────── */
+
+static void
+setup_ui_and_timers (GApplication *app,
+                     AppData      *app_data)
+{
     app_data->clipboard = gtk_clipboard_get (GDK_SELECTION_CLIPBOARD);
 
     create_treeview (app_data);
@@ -262,22 +351,23 @@ otpclient_application_activate (GApplication *app)
     g_notification_set_priority (app_data->notification, G_NOTIFICATION_PRIORITY_NORMAL);
     GIcon *icon = g_themed_icon_new ("com.github.paolostivanin.OTPClient");
     g_notification_set_icon (app_data->notification, icon);
-    g_notification_set_body (app_data->notification, _("OTP value has been copied to the clipboard"));
+    g_notification_set_body (app_data->notification,
+                              _("OTP value has been copied to the clipboard"));
     g_object_unref (icon);
 
-    app_data->source_id = g_timeout_add_full (G_PRIORITY_DEFAULT, 1000, traverse_liststore, app_data, NULL);
+    app_data->source_id =
+        g_timeout_add_full (G_PRIORITY_DEFAULT, 1000, traverse_liststore, app_data, NULL);
 
     setup_dbus_listener (app_data);
 
-    // set last user activity to now, so we have a starting point for the autolock feature
     app_data->last_user_activity = g_date_time_new_now_local ();
-    app_data->source_id_last_activity = g_timeout_add_seconds (1, check_inactivity, app_data);
+    app_data->source_id_last_activity =
+        g_timeout_add_seconds (1, check_inactivity, app_data);
 
-    self->app_data = app_data;
-
-    gtk_widget_show_all (app_data->main_window);
-    gtk_widget_hide (app_data->search_entry);
+    (void) app;
 }
+
+/* ── finalize / class / init ───────────────────────────────────────────── */
 
 static void
 otpclient_application_finalize (GObject *object)
@@ -295,12 +385,12 @@ otpclient_application_finalize (GObject *object)
 static void
 otpclient_application_class_init (OtpclientApplicationClass *klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
-    GApplicationClass *app_class = G_APPLICATION_CLASS (klass);
+    GObjectClass     *object_class = G_OBJECT_CLASS (klass);
+    GApplicationClass *app_class   = G_APPLICATION_CLASS (klass);
 
     object_class->finalize = otpclient_application_finalize;
-    app_class->activate = otpclient_application_activate;
-    app_class->shutdown = otpclient_application_shutdown;
+    app_class->activate    = otpclient_application_activate;
+    app_class->shutdown    = otpclient_application_shutdown;
 }
 
 static void
@@ -333,6 +423,8 @@ otpclient_application_clear_app_data (OtpclientApplication *app)
     app->app_data = NULL;
 }
 
+/* ── Private helpers ───────────────────────────────────────────────────── */
+
 static void
 set_config_data (gint    *width,
                  gint    *height,
@@ -340,23 +432,25 @@ set_config_data (gint    *width,
 {
     GKeyFile *kf = get_kf_ptr ();
     if (kf != NULL) {
-        *width = g_key_file_get_integer (kf, "config", "window_width", NULL);
+        *width  = g_key_file_get_integer (kf, "config", "window_width",  NULL);
         *height = g_key_file_get_integer (kf, "config", "window_height", NULL);
-        app_data->show_next_otp = g_key_file_get_boolean (kf, "config", "show_next_otp", NULL);
-        app_data->disable_notifications = g_key_file_get_boolean (kf, "config", "notifications", NULL);
+        app_data->show_next_otp         = g_key_file_get_boolean (kf, "config", "show_next_otp",      NULL);
+        app_data->disable_notifications = g_key_file_get_boolean (kf, "config", "notifications",      NULL);
         app_data->show_validity_seconds = g_key_file_get_boolean (kf, "config", "show_validity_seconds", NULL);
-        app_data->auto_lock = g_key_file_get_boolean (kf, "config", "auto_lock", NULL);
-        app_data->inactivity_timeout = g_key_file_get_integer (kf, "config", "inactivity_timeout", NULL);
-        app_data->use_dark_theme = g_key_file_get_boolean (kf, "config", "dark_theme", NULL);
-        app_data->use_tray = g_key_file_get_boolean (kf, "config", "use_tray", NULL);
-        app_data->use_secret_service = g_key_file_get_boolean (kf, "config", "use_secret_service", NULL);
+        app_data->auto_lock             = g_key_file_get_boolean (kf, "config", "auto_lock",           NULL);
+        app_data->inactivity_timeout    = g_key_file_get_integer (kf, "config", "inactivity_timeout",  NULL);
+        app_data->use_dark_theme        = g_key_file_get_boolean (kf, "config", "dark_theme",          NULL);
+        app_data->use_tray              = g_key_file_get_boolean (kf, "config", "use_tray",            NULL);
+        app_data->use_secret_service    = g_key_file_get_boolean (kf, "config", "use_secret_service",  NULL);
         if (g_key_file_has_key (kf, "config", "search_provider_enabled", NULL)) {
-            app_data->search_provider_enabled = g_key_file_get_boolean (kf, "config", "search_provider_enabled", NULL);
+            app_data->search_provider_enabled =
+                g_key_file_get_boolean (kf, "config", "search_provider_enabled", NULL);
         } else {
             app_data->search_provider_enabled = TRUE;
         }
         load_validity_colors (kf, app_data);
-        g_object_set (gtk_settings_get_default (), "gtk-application-prefer-dark-theme", app_data->use_dark_theme, NULL);
+        g_object_set (gtk_settings_get_default (),
+                      "gtk-application-prefer-dark-theme", app_data->use_dark_theme, NULL);
         g_key_file_free (kf);
     }
 }
@@ -374,29 +468,32 @@ get_db_path (AppData *app_data)
             show_message_dialog (app_data->main_window, err->message, GTK_MESSAGE_ERROR);
             g_key_file_free (kf);
             g_clear_error (&err);
+            g_free (cfg_file_path);
             return NULL;
         }
         db_path = g_key_file_get_string (kf, "config", "db_path", NULL);
-        if (db_path == NULL) {
-            goto new_db;
+        if (db_path != NULL) {
+            if (!g_file_test (db_path, G_FILE_TEST_EXISTS)) {
+                gchar *msg = g_strconcat ("Database file/location:\n<b>", db_path,
+                                          "</b>\ndoes not exist. A new database will be created.",
+                                          NULL);
+                show_message_dialog (app_data->main_window, msg, GTK_MESSAGE_ERROR);
+                g_free (msg);
+                g_free (db_path);
+                db_path = NULL;
+            } else {
+                g_free (cfg_file_path);
+                g_key_file_free (kf);
+                return db_path;
+            }
         }
-        if (!g_file_test (db_path, G_FILE_TEST_EXISTS)) {
-            gchar *msg = g_strconcat ("Database file/location:\n<b>", db_path, "</b>\ndoes not exist. A new database will be created.", NULL);
-            show_message_dialog (app_data->main_window, msg, GTK_MESSAGE_ERROR);
-            g_free (msg);
-            g_free (db_path);
-            db_path = NULL;
-            goto new_db;
-        }
-        goto end;
     }
-    new_db: ; // empty statement workaround
-    GtkFileChooserNative *dialog = gtk_file_chooser_native_new (_("Select database location"),
-                                                                GTK_WINDOW (app_data->main_window),
-                                                                app_data->open_db_file_action,
-                                                                "OK",
-                                                                "Cancel");
 
+    GtkFileChooserNative *dialog =
+        gtk_file_chooser_native_new (_("Select database location"),
+                                     GTK_WINDOW (app_data->main_window),
+                                     app_data->open_db_file_action,
+                                     "OK", "Cancel");
     GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);
     gtk_file_chooser_set_do_overwrite_confirmation (chooser, TRUE);
     gtk_file_chooser_set_select_multiple (chooser, FALSE);
@@ -404,9 +501,7 @@ get_db_path (AppData *app_data)
         gtk_file_chooser_set_current_name (chooser, "NewDatabase.enc");
     }
 
-    gint res = gtk_native_dialog_run (GTK_NATIVE_DIALOG (dialog));
-
-    if (res == GTK_RESPONSE_ACCEPT) {
+    if (gtk_native_dialog_run (GTK_NATIVE_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT) {
         db_path = gtk_file_chooser_get_filename (chooser);
         g_key_file_set_string (kf, "config", "db_path", db_path);
         if (!g_key_file_save_to_file (kf, cfg_file_path, &err)) {
@@ -415,12 +510,11 @@ get_db_path (AppData *app_data)
         }
     }
 
-    // clear any password that may have been previously set, thus avoiding using a wrong password with a new database
-    secret_password_clear (OTPCLIENT_SCHEMA, NULL, on_password_cleared, NULL, "string", "main_pwd", NULL);
+    /* Clear any stored password so it is not used with the newly selected DB */
+    secret_password_clear (OTPCLIENT_SCHEMA, NULL, on_password_cleared, NULL,
+                           "string", "main_pwd", NULL);
 
     g_object_unref (dialog);
-
-    end:
     g_free (cfg_file_path);
     g_key_file_free (kf);
 
@@ -433,30 +527,32 @@ set_open_db_action (GtkWidget *btn,
                     gpointer   user_data)
 {
     CAST_USER_DATA (AppData, app_data, user_data);
-    app_data->open_db_file_action = g_strcmp0 (gtk_widget_get_name (btn), "diag_rc_restoredb_btn") == 0 ? GTK_FILE_CHOOSER_ACTION_OPEN : GTK_FILE_CHOOSER_ACTION_SAVE;
+    app_data->open_db_file_action =
+        g_strcmp0 (gtk_widget_get_name (btn), "diag_rc_restoredb_btn") == 0
+        ? GTK_FILE_CHOOSER_ACTION_OPEN
+        : GTK_FILE_CHOOSER_ACTION_SAVE;
     gtk_dialog_response (GTK_DIALOG (app_data->diag_rcdb), GTK_RESPONSE_OK);
 }
 
 static void
 init_app_defaults (AppData *app_data)
 {
-    app_data->app_locked = FALSE;
-    app_data->show_next_otp = FALSE; // next otp not shown by default
-    app_data->disable_notifications = FALSE; // notifications enabled by default
-    app_data->show_validity_seconds = FALSE; // validity is shown as a pie chart by default
-    gdk_rgba_parse (&app_data->validity_color, "#33A659");
+    app_data->app_locked             = FALSE;
+    app_data->show_next_otp          = FALSE;
+    app_data->disable_notifications  = FALSE;
+    app_data->show_validity_seconds  = FALSE;
+    gdk_rgba_parse (&app_data->validity_color,         "#33A659");
     gdk_rgba_parse (&app_data->validity_warning_color, "#D95940");
-    app_data->auto_lock = FALSE; // disabled by default
-    app_data->inactivity_timeout = 0; // never
-    app_data->use_dark_theme = FALSE; // light theme by default
-    app_data->use_secret_service = TRUE; // secret service enabled by default
-    app_data->is_reorder_active = FALSE; // when app is started, reorder is not set
-    app_data->use_tray = FALSE; // do not use tray by default
-    app_data->search_provider_enabled = TRUE; // search provider enabled by default
-    // open_db_file_action is set only on first startup and not when the db is deleted but the cfg file is there, therefore we need a default action
-    app_data->open_db_file_action = GTK_FILE_CHOOSER_ACTION_SAVE;
-    app_data->window_width = 0;
-    app_data->window_height = 0;
+    app_data->auto_lock              = FALSE;
+    app_data->inactivity_timeout     = 0;
+    app_data->use_dark_theme         = FALSE;
+    app_data->use_secret_service     = TRUE;
+    app_data->is_reorder_active      = FALSE;
+    app_data->use_tray               = FALSE;
+    app_data->search_provider_enabled = TRUE;
+    app_data->open_db_file_action    = GTK_FILE_CHOOSER_ACTION_SAVE;
+    app_data->window_width           = 0;
+    app_data->window_height          = 0;
 }
 
 static void
@@ -483,10 +579,10 @@ load_validity_colors (GKeyFile *kf,
 static void
 init_db_defaults (AppData *app_data)
 {
-    app_data->db_data->key_stored = FALSE; // at startup, we don't know whether the key is stored or not
+    app_data->db_data->key_stored                = FALSE;
     app_data->db_data->max_file_size_from_memlock = 0;
-    app_data->db_data->objects_hash = NULL;
-    app_data->db_data->data_to_add = NULL;
+    app_data->db_data->objects_hash              = NULL;
+    app_data->db_data->data_to_add               = NULL;
 }
 
 static void
@@ -497,18 +593,12 @@ cleanup_app_data (AppData *app_data)
     }
 
     if (app_data->main_window != NULL) {
+        /* Destroying the window also triggers OtpclientWindow::dispose,
+         * which releases the three GtkBuilder instances. */
         gtk_widget_destroy (app_data->main_window);
     }
 
-    if (app_data->builder != NULL) {
-        g_object_unref (app_data->builder);
-    }
-    if (app_data->add_popover_builder != NULL) {
-        g_object_unref (app_data->add_popover_builder);
-    }
-    if (app_data->settings_popover_builder != NULL) {
-        g_object_unref (app_data->settings_popover_builder);
-    }
+    /* Builders are owned by the window; do NOT unref them here. */
 
     if (app_data->db_data != NULL) {
         g_clear_pointer (&app_data->db_data->db_path, g_free);

--- a/src/gui/otpclient-application.h
+++ b/src/gui/otpclient-application.h
@@ -6,16 +6,12 @@
 G_BEGIN_DECLS
 
 #define OTPCLIENT_TYPE_APPLICATION (otpclient_application_get_type ())
-#define OTPCLIENT_APPLICATION(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), OTPCLIENT_TYPE_APPLICATION, OtpclientApplication))
-#define OTPCLIENT_IS_APPLICATION(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OTPCLIENT_TYPE_APPLICATION))
 
-typedef struct _OtpclientApplication OtpclientApplication;
-typedef struct _OtpclientApplicationClass OtpclientApplicationClass;
+G_DECLARE_FINAL_TYPE (OtpclientApplication, otpclient_application,
+                      OTPCLIENT, APPLICATION, GtkApplication)
 
-GType otpclient_application_get_type (void);
+OtpclientApplication *otpclient_application_new            (void);
 
-OtpclientApplication *otpclient_application_new (void);
-
-void otpclient_application_clear_app_data (OtpclientApplication *app);
+void                  otpclient_application_clear_app_data (OtpclientApplication *app);
 
 G_END_DECLS

--- a/src/gui/otpclient-window.h
+++ b/src/gui/otpclient-window.h
@@ -6,17 +6,18 @@
 G_BEGIN_DECLS
 
 #define OTPCLIENT_TYPE_WINDOW (otpclient_window_get_type ())
-#define OTPCLIENT_WINDOW(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), OTPCLIENT_TYPE_WINDOW, OtpclientWindow))
-#define OTPCLIENT_IS_WINDOW(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OTPCLIENT_TYPE_WINDOW))
 
-typedef struct _OtpclientWindow OtpclientWindow;
-typedef struct _OtpclientWindowClass OtpclientWindowClass;
-
-GType otpclient_window_get_type (void);
+G_DECLARE_FINAL_TYPE (OtpclientWindow, otpclient_window,
+                      OTPCLIENT, WINDOW, GtkApplicationWindow)
 
 OtpclientWindow *otpclient_window_new (GtkApplication *app,
                                        gint            width,
                                        gint            height,
                                        AppData        *app_data);
+
+/* Builder accessors — ownership stays with the window; callers must not unref */
+GtkBuilder *otpclient_window_get_builder                  (OtpclientWindow *self);
+GtkBuilder *otpclient_window_get_add_popover_builder      (OtpclientWindow *self);
+GtkBuilder *otpclient_window_get_settings_popover_builder (OtpclientWindow *self);
 
 G_END_DECLS

--- a/src/gui/setup-signals-shortcuts.c
+++ b/src/gui/setup-signals-shortcuts.c
@@ -9,31 +9,45 @@
 #include "edit-row-cb.h"
 #include "show-qr-cb.h"
 #include "change-db-cb.h"
+#include "../common/macros.h"
 
 static const char *signal_names[] = {
-        "toggle-reorder-button", "lock-app",
-        "change-db", "change-pwd", "show-settings", "show-kb-shortcuts",
-        "scan-webcam", "manual-add", "edit-row", "show-qr"
+    "toggle-reorder-button", "lock-app",
+    "change-db", "change-pwd", "show-settings", "show-kb-shortcuts",
+    "scan-webcam", "manual-add", "edit-row", "show-qr"
 };
 
 static void setup_signals   (void);
-
 static void connect_signals (AppData *app_data);
+
+static void
+toggle_reorder_cb_shortcut (GtkWidget *window UNUSED,
+                             gpointer   user_data)
+{
+    CAST_USER_DATA (AppData, app_data, user_data);
+    GtkToggleButton *btn =
+        GTK_TOGGLE_BUTTON (gtk_builder_get_object (app_data->builder,
+                                                    "reorder_toggle_btn_id"));
+    if (btn != NULL) {
+        gtk_toggle_button_set_active (btn, !gtk_toggle_button_get_active (btn));
+    }
+}
 
 
 void
 setup_kb_shortcuts (AppData *app_data)
 {
-    // Used letters: r,l,h,w,m,b,o,e,s,k
-    // hide-all-otps is in src/treeview.c
+    /* Used letters: r, l, h, w, m, b, o, e, s, k
+     * hide-all-otps is registered in src/gui/treeview.c */
     setup_signals ();
     connect_signals (app_data);
 
-    GtkBindingSet *mw_binding_set = gtk_binding_set_by_class (GTK_APPLICATION_WINDOW_GET_CLASS(app_data->main_window));
+    GtkBindingSet *mw_binding_set =
+        gtk_binding_set_by_class (GTK_APPLICATION_WINDOW_GET_CLASS (app_data->main_window));
 
-    gtk_binding_entry_add_signal(mw_binding_set, GDK_KEY_r, GDK_CONTROL_MASK, signal_names[0], 0);
+    gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_r, GDK_CONTROL_MASK, signal_names[0], 0);
     if (app_data->auto_lock == TRUE || app_data->inactivity_timeout > 0) {
-        // auto-lock is enabled, so secret service is disabled, therefore we allow the shortcut
+        /* auto-lock is enabled → secret service is disabled → allow Ctrl+L shortcut */
         gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_l, GDK_CONTROL_MASK, signal_names[1], 0);
     }
     gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_b, GDK_CONTROL_MASK, signal_names[2], 0);
@@ -41,7 +55,7 @@ setup_kb_shortcuts (AppData *app_data)
     gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_s, GDK_CONTROL_MASK, signal_names[4], 0);
     gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_k, GDK_CONTROL_MASK, signal_names[5], 0);
 
-    // GDM_MOD1_MASK: the fourth modifier key (it depends on the modifier mapping of the X server which key is interpreted as this modifier, but normally it is the Alt key).
+    /* GDK_MOD1_MASK: Alt key (X11) */
     gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_w, GDK_MOD1_MASK, signal_names[6], 0);
     gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_m, GDK_MOD1_MASK, signal_names[7], 0);
     gtk_binding_entry_add_signal (mw_binding_set, GDK_KEY_e, GDK_MOD1_MASK, signal_names[8], 0);
@@ -52,11 +66,12 @@ setup_kb_shortcuts (AppData *app_data)
 static void
 setup_signals (void)
 {
-    for (int i = 0; i < G_N_ELEMENTS(signal_names); ++i) {
+    for (int i = 0; i < (int) G_N_ELEMENTS (signal_names); ++i) {
         if (g_signal_lookup (signal_names[i], OTPCLIENT_TYPE_WINDOW) == 0) {
             g_signal_new (signal_names[i], OTPCLIENT_TYPE_WINDOW,
-                          G_SIGNAL_RUN_FIRST | G_SIGNAL_ACTION, 0, NULL, NULL,
-                          NULL, G_TYPE_NONE, 0);
+                          G_SIGNAL_RUN_FIRST | G_SIGNAL_ACTION,
+                          0, NULL, NULL, NULL,
+                          G_TYPE_NONE, 0);
         }
     }
 }
@@ -65,21 +80,25 @@ setup_signals (void)
 static void
 connect_signals (AppData *app_data)
 {
-    struct {
+    static const struct {
         const char *signal_name;
-        GCallback callback;
+        GCallback   callback;
     } signal_connections[] = {
-            {"change-db", G_CALLBACK(change_db_cb_shortcut)},
-            {"change-pwd", G_CALLBACK(change_pwd_cb_shortcut)},
-            {"show-settings", G_CALLBACK(show_settings_cb_shortcut)},
-            {"show-kb-shortcuts", G_CALLBACK(show_kbs_cb_shortcut)},
-            {"scan-webcam", G_CALLBACK(webcam_add_cb_shortcut)},
-            {"manual-add", G_CALLBACK(manual_add_cb_shortcut)},
-            {"edit-row", G_CALLBACK(edit_row_cb_shortcut)},
-            {"show-qr", G_CALLBACK(show_qr_cb_shortcut)}
+        { "toggle-reorder-button", G_CALLBACK (toggle_reorder_cb_shortcut) },
+        { "change-db",             G_CALLBACK (change_db_cb_shortcut)       },
+        { "change-pwd",            G_CALLBACK (change_pwd_cb_shortcut)      },
+        { "show-settings",         G_CALLBACK (show_settings_cb_shortcut)   },
+        { "show-kb-shortcuts",     G_CALLBACK (show_kbs_cb_shortcut)        },
+        { "scan-webcam",           G_CALLBACK (webcam_add_cb_shortcut)      },
+        { "manual-add",            G_CALLBACK (manual_add_cb_shortcut)      },
+        { "edit-row",              G_CALLBACK (edit_row_cb_shortcut)        },
+        { "show-qr",               G_CALLBACK (show_qr_cb_shortcut)        },
     };
 
-    for (int i = 0; i < G_N_ELEMENTS(signal_connections); ++i) {
-        g_signal_connect (app_data->main_window, signal_connections[i].signal_name, signal_connections[i].callback, app_data);
+    for (int i = 0; i < (int) G_N_ELEMENTS (signal_connections); ++i) {
+        g_signal_connect (app_data->main_window,
+                          signal_connections[i].signal_name,
+                          signal_connections[i].callback,
+                          app_data);
     }
 }


### PR DESCRIPTION
- Replace manual typedef/struct declarations with G_DECLARE_FINAL_TYPE in otpclient-application.h and otpclient-window.h

- Move GtkBuilder ownership from AppData into OtpclientWindow: builders are created in otpclient_window_new(), stored in the instance struct, and released in a new dispose() vfunc; AppData holds non-owning references documented clearly in data.h

- Replace key_press_event + GdkEventKey with GtkEventControllerKey (available since GTK 3.24, the project's minimum)

- Replace size-allocate (fires on every layout pass) with configure-event (fires only on actual window resize) for window-size tracking

- Fix show_all + hide double-layout: set no_show_all on the search entry before gtk_widget_show_all() so no separate hide call is needed

- Split the ~200-line activate() into three focused helpers: resolve_db_path(), load_db_with_password(), setup_ui_and_timers()

- Replace goto retry / goto retry_change_file with a do-while loop in the password-prompt path

- Remove the toggle-reorder-button signal from otpclient_window_class_init; it is now registered and connected entirely inside setup-signals-shortcuts.c alongside all other keyboard-shortcut signals

- Extract store_data(), save_window_size(), save_sort_order() from otpclient-window.c into a new config-misc.c/h utility module