### PR TITLE
fix: HOTP init off by 10^6x, is_steam flag leak, GError misuse, memory leaks

### DIFF
--- a/src/cli/exec-action.c
+++ b/src/cli/exec-action.c
@@ -184,8 +184,10 @@ gboolean exec_action (CmdlineOpts  *cmdline_opts,
         update_db (db_data, &err);
         if (err != NULL && !g_error_matches (err, missing_file_gquark (), MISSING_FILE_ERRCODE)) {
             g_printerr ("Error while updating the database: %s\n", err->message);
+            g_clear_error (&err);
             return FALSE;
         }
+        g_clear_error (&err);
         reload_db (db_data, &err);
         if (err != NULL && !g_error_matches (err, missing_file_gquark (), MISSING_FILE_ERRCODE)) {
             g_printerr ("Error while reloading the database: %s\n", err->message);
@@ -392,10 +394,13 @@ get_use_secretservice (void)
         if (!g_key_file_load_from_file (kf, cfg_file_path, G_KEY_FILE_NONE, &err)) {
             g_printerr ("%s\n", err->message);
             g_key_file_free (kf);
+            g_free (cfg_file_path);
             g_clear_error (&err);
             return FALSE;
         }
         use_secret_service = g_key_file_get_boolean (kf, "config", "use_secret_service", NULL);
     }
+    g_key_file_free (kf);
+    g_free (cfg_file_path);
     return use_secret_service;
 }

--- a/src/common/aegis.c
+++ b/src/common/aegis.c
@@ -496,13 +496,10 @@ export_aegis (const gchar   *export_path,
             goto cleanup_and_exit;
         }
         if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), jbuf, jbuf_size, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "couldn't dump json data to file");
             g_free (jbuf);
             goto cleanup_and_exit;
         }
         g_free (jbuf);
-    } else {
-        g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "couldn't create the file object");
     }
 
     cleanup_and_exit:
@@ -515,7 +512,12 @@ export_aegis (const gchar   *export_path,
     }
     g_object_unref (out_gfile);
 
-    return (err != NULL ? g_strdup (err->message) : NULL);
+    if (err != NULL) {
+        gchar *msg = g_strdup (err->message);
+        g_clear_error (&err);
+        return msg;
+    }
+    return NULL;
 }
 
 

--- a/src/common/authpro.c
+++ b/src/common/authpro.c
@@ -82,8 +82,8 @@ export_authpro (const gchar *export_path,
 
     json_t *db_obj, *export_obj;
     gsize index;
-    gboolean is_steam = FALSE;
     json_array_foreach (json_db_data, index, db_obj) {
+        gboolean is_steam = FALSE;
         export_obj = json_object ();
         const gchar *issuer = json_string_value (json_object_get (db_obj, "issuer"));
         if (issuer != NULL) {
@@ -172,23 +172,18 @@ export_authpro (const gchar *export_path,
         gcry_cipher_close (hd);
 
         if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), header, 16, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "Couldn't write header to file.");
             goto enc_end;
         }
         if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), salt, AUTHPRO_SALT_TAG, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "Couldn't write salt to file.");
             goto enc_end;
         }
         if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), iv, AUTHPRO_IV, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "Couldn't write iv to file.");
             goto enc_end;
         }
         if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), enc_buf, json_data_size, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "Couldn't write payload to file.");
             goto enc_end;
         }
         if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), tag, AUTHPRO_SALT_TAG, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "Couldn't write tag to file");
             goto enc_end;
         }
         enc_end:
@@ -198,9 +193,7 @@ export_authpro (const gchar *export_path,
         g_free (salt);
     } else {
         // write the plain json to disk
-        if (g_output_stream_write (G_OUTPUT_STREAM(out_stream), json_data, json_data_size, NULL, &err) == -1) {
-            g_set_error (&err, generic_error_gquark (), GENERIC_ERRCODE, "couldn't dump json data to file");
-        }
+        g_output_stream_write (G_OUTPUT_STREAM(out_stream), json_data, json_data_size, NULL, &err);
     }
     g_object_unref (out_stream);
     g_object_unref (out_gfile);
@@ -210,7 +203,12 @@ export_authpro (const gchar *export_path,
     json_decref (auth_array);
     json_decref (root);
 
-    return (err != NULL ? g_strdup (err->message) : NULL);
+    if (err != NULL) {
+        gchar *msg = g_strdup (err->message);
+        g_clear_error (&err);
+        return msg;
+    }
+    return NULL;
 }
 
 

--- a/src/gui/otpclient-application.c
+++ b/src/gui/otpclient-application.c
@@ -140,7 +140,7 @@ otpclient_application_activate (GApplication *app)
     /* Subtract 3 s so "last_hotp" is valid from the very first run */
     GDateTime *now = g_date_time_new_now_local ();
     app_data->db_data->last_hotp_update =
-        g_date_time_add_seconds (now, -(G_TIME_SPAN_SECOND * HOTP_RATE_LIMIT_IN_SEC));
+        g_date_time_add_seconds (now, -HOTP_RATE_LIMIT_IN_SEC);
     g_date_time_unref (now);
 
     if (!load_db_with_password (app, app_data, memlock_value)) {


### PR DESCRIPTION
- otpclient-application.c: g_date_time_add_seconds takes seconds, not
  microseconds; remove erroneous G_TIME_SPAN_SECOND multiplier that
  subtracted ~35 days instead of 3 seconds
- authpro.c: move is_steam inside the loop so it resets per entry;
  previously all entries after the first Steam token were exported
  as Steam type
- exec-action.c: clear GError between update_db and reload_db so
  reload_db does not silently bail via g_return_if_fail
- exec-action.c: fix leaks of GKeyFile and cfg_file_path in
  get_use_secretservice()
- aegis.c, authpro.c: free GError in export functions; remove
  redundant g_set_error calls that overwrote already-set GError
